### PR TITLE
Docs: update documentation for security PR changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ When code or project structure changes, run a sub-agent after completing the tas
 │   │   └── utils/
 │   │       ├── session.py     # JWT encode/decode
 │   │       ├── session_store.py # In-memory server-side session store
+│   │       ├── sql_safety.py  # SQL injection protection (safe_name, safe_identifier)
 │   │       └── cache.py       # Central cache clearing utility
 │   ├── tests/
 │   │   ├── conftest.py        # FakeConnection mock + fixtures
@@ -53,6 +54,7 @@ When code or project structure changes, run a sub-agent after completing the tas
 │   │   ├── test_dag.py        # 5 tests
 │   │   ├── test_search.py     # 5 tests
 │   │   ├── test_session_store.py # 6 tests
+│   │   ├── test_sql_safety.py # 8 tests
 │   │   └── test_integration.py # 12 tests (requires real SR + env vars)
 │   └── API.md                 # Detailed API documentation
 └── frontend/
@@ -120,7 +122,7 @@ uvicorn app.main:app --host 0.0.0.0 --port 8001
 ```bash
 cd backend
 source venv/bin/activate
-python -m pytest tests/ -v                    # Unit tests (45 tests, mock)
+python -m pytest tests/ -v                    # Unit tests (57 tests, mock)
 python -m pytest tests/test_integration.py -v -s  # Integration tests (requires SR env vars)
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ docker run -d -p 8001:8001 \
 
 Open http://localhost:8001 and log in with your StarRocks credentials.
 
+> **Note:** The Docker image runs a single worker (`--workers 1`) because the in-memory session store is per-process. For multi-worker deployments, use a shared session backend (e.g., Redis) or sticky sessions.
+
 ### Development
 
 **Prerequisites:** Python 3.10+, Node.js 18+, npm 9+
@@ -226,6 +228,7 @@ npm run build
 | `test_dag.py` | 5 | Object-hierarchy, role-hierarchy, full, filters, schema |
 | `test_search.py` | 5 | Search API |
 | `test_session_store.py` | 6 | Server-side session store |
+| `test_sql_safety.py` | 8 | SQL injection protection (safe_name, safe_identifier) |
 | `test_integration.py` | 12 | Full API against real StarRocks (skipped without env vars) |
 
 ## Environment Variables

--- a/backend/API.md
+++ b/backend/API.md
@@ -7,8 +7,19 @@
 
 ## Authentication
 
-All APIs require JWT Bearer token authentication (except login).
-The token contains StarRocks connection info; each request connects to StarRocks with the user's own credentials.
+All APIs require JWT Bearer token authentication (except login and logout).
+The JWT token contains only a `session_id` and `username` — credentials are stored server-side in an in-memory session store. Each request resolves the session to obtain StarRocks credentials and opens a per-request connection.
+
+**JWT Payload Structure:**
+```json
+{
+  "session_id": "a1b2c3d4...",
+  "username": "admin",
+  "exp": 1712345678
+}
+```
+
+> **Note:** Passwords are never included in the JWT token. They are stored only in the server-side session store.
 
 ```
 Authorization: Bearer <token>
@@ -20,7 +31,7 @@ Authorization: Bearer <token>
 
 ### POST `/api/auth/login`
 
-Tests the StarRocks connection and issues a JWT token.
+Tests the StarRocks connection, creates a server-side session, and issues a JWT token.
 
 **Request Body**
 ```json
@@ -76,6 +87,24 @@ Returns the currently authenticated user's info.
 | roles | string[] | Assigned role list |
 | default_role | string\|null | Currently active role |
 | is_user_admin | boolean | Whether user has root or user_admin role. If true, can query other users' privileges |
+
+---
+
+### POST `/api/auth/logout`
+
+Invalidates the server-side session associated with the JWT token. The token becomes unusable after logout.
+
+**Headers**
+```
+Authorization: Bearer <token>
+```
+
+**Response** `200 OK`
+```json
+{ "detail": "Logged out" }
+```
+
+> **Note:** Returns 200 even if no valid token is provided (graceful logout).
 
 ---
 


### PR DESCRIPTION
## Summary
Follow-up to #1 — updates documentation that was missed in the security PR.

- **API.md**: Add `POST /api/auth/logout` endpoint, update auth description to reflect new JWT structure (`session_id` only, no passwords), add JWT payload example
- **README.md**: Add `test_sql_safety.py` to test coverage table, add Docker single-worker limitation note
- **CLAUDE.md**: Add `sql_safety.py` and `test_sql_safety.py` to architecture tree, update test count (45 → 57)

## Changes
| File | What changed |
|------|-------------|
| `backend/API.md` | Logout endpoint docs, JWT structure update |
| `README.md` | test_sql_safety coverage, Docker workers note |
| `CLAUDE.md` | sql_safety.py in tree, test count |

## Depends on
Merge after #1 (includes #1's changes as base)

## Test plan
- [x] No code changes, docs only
- [x] Verified all gaps from PR #1 review are addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)