### PR TITLE
Fix: DB node path showing duplicate name

### DIFF
--- a/frontend/src/components/panels/ObjectDetailPanel.tsx
+++ b/frontend/src/components/panels/ObjectDetailPanel.tsx
@@ -106,8 +106,13 @@ export default function ObjectDetailPanel() {
     return { name, type: rowType, row };
   });
 
-  // Path display
-  const pathParts = [parsed.catalog, parsed.database, parsed.name || selectedNode.label].filter(Boolean);
+  // Path display — avoid duplicating label when node IS the catalog/database itself
+  const nodeType = selectedNode.type.toLowerCase();
+  const pathParts = nodeType === "catalog"
+    ? [selectedNode.label]
+    : nodeType === "database"
+      ? [parsed.catalog, selectedNode.label].filter(Boolean)
+      : [parsed.catalog, parsed.database, parsed.name || selectedNode.label].filter(Boolean);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
Fixes path display when clicking a database node in the Object Detail panel.

**Before:** `default_catalog / tpcds / tpcds`
**After:** `default_catalog / tpcds`

## Root cause
`getNodeContext()` returns `name: node.label`, which equals the database name for DB nodes. The path was constructed as `[catalog, database, name]` without checking node type, causing duplication.

## Fix
Path construction is now type-aware:
- **Catalog** node → `[label]`
- **Database** node → `[catalog, label]`
- **Table/View/etc** → `[catalog, database, label]`

## Test plan
- [x] Click DB node → path shows `catalog / db` (no duplicate)
- [x] Click table node → path shows `catalog / db / table` (unchanged)
- [x] Click catalog node → path shows `catalog` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)