### PR TITLE
Test: add 180 unit tests for core service modules

### DIFF
--- a/backend/tests/test_bfs_resolver.py
+++ b/backend/tests/test_bfs_resolver.py
@@ -1,0 +1,338 @@
+"""Unit tests for backend/app/services/admin/bfs_resolver.py"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.models.schemas import PrivilegeGrant
+from app.services.admin.bfs_resolver import (
+    _bfs_child_roles,
+    _bfs_user_privs,
+    _finalize,
+    _find_ancestors_with_grants,
+)
+from app.services.common.grant_classifier import ObjectQuery, Relevance
+
+
+# ── Helpers ──
+
+def _grant(
+    grantee: str = "role_a",
+    grantee_type: str = "ROLE",
+    privilege_type: str = "SELECT",
+    object_type: str = "TABLE",
+    object_catalog: str | None = "cat1",
+    object_database: str | None = "db1",
+    object_name: str | None = "t1",
+    source: str = "direct",
+    is_grantable: bool = False,
+) -> PrivilegeGrant:
+    return PrivilegeGrant(
+        grantee=grantee,
+        grantee_type=grantee_type,
+        privilege_type=privilege_type,
+        object_type=object_type,
+        object_catalog=object_catalog,
+        object_database=object_database,
+        object_name=object_name,
+        source=source,
+        is_grantable=is_grantable,
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# _bfs_child_roles
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestBfsChildRoles:
+    def test_simple_chain(self):
+        """root -> admin -> analyst: both admin and analyst inherit root's privs."""
+        role_privs = {"root": {"SELECT", "INSERT"}}
+        children_of = {
+            "root": ["admin"],
+            "admin": ["analyst"],
+        }
+        result = _bfs_child_roles(role_privs, children_of)
+        assert "admin" in result
+        assert "analyst" in result
+        assert result["admin"][0] == {"SELECT", "INSERT"}
+        assert result["analyst"][0] == {"SELECT", "INSERT"}
+        # origin should be root for both
+        assert result["admin"][1] == "root"
+        assert result["analyst"][1] == "root"
+
+    def test_diamond_inheritance(self):
+        """A -> B, A -> C, B -> D, C -> D: D inherits from both paths."""
+        role_privs = {"A": {"SELECT", "INSERT"}}
+        children_of = {
+            "A": ["B", "C"],
+            "B": ["D"],
+            "C": ["D"],
+        }
+        result = _bfs_child_roles(role_privs, children_of)
+        assert "D" in result
+        assert result["D"][0] == {"SELECT", "INSERT"}
+
+    def test_no_children(self):
+        """Role with privs but no children yields empty result."""
+        role_privs = {"lonely": {"SELECT"}}
+        children_of: dict[str, list[str]] = {}
+        result = _bfs_child_roles(role_privs, children_of)
+        assert result == {}
+
+    def test_cycle_protection(self):
+        """Cycles in the graph should not cause infinite loop."""
+        role_privs = {"A": {"SELECT"}}
+        children_of = {
+            "A": ["B"],
+            "B": ["C"],
+            "C": ["A"],  # cycle back to A
+        }
+        result = _bfs_child_roles(role_privs, children_of)
+        assert "B" in result
+        assert "C" in result
+        # A is in role_privs and visited first, should not appear as child
+        # (it is the seed, not a child)
+
+    def test_multiple_seeds(self):
+        """Multiple roles with different privs propagate independently."""
+        role_privs = {
+            "role_x": {"SELECT"},
+            "role_y": {"INSERT"},
+        }
+        children_of = {
+            "role_x": ["shared_child"],
+            "role_y": ["shared_child"],
+        }
+        result = _bfs_child_roles(role_privs, children_of)
+        assert "shared_child" in result
+        # shared_child should accumulate privs from both seeds
+        assert result["shared_child"][0] >= {"SELECT", "INSERT"}
+
+    def test_empty_inputs(self):
+        """Empty role_privs yields empty result."""
+        result = _bfs_child_roles({}, {"A": ["B"]})
+        assert result == {}
+
+
+# ══════════════════════════════════════════════════════════════════════
+# _bfs_user_privs
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestBfsUserPrivs:
+    @patch("app.services.admin.bfs_resolver.get_user_roles")
+    def test_direct_role_match(self, mock_get_user_roles):
+        """User has a role directly in role_privs."""
+        mock_get_user_roles.return_value = ["analyst"]
+        role_privs = {"analyst": {"SELECT", "INSERT"}}
+        conn = object()  # dummy
+        result = _bfs_user_privs(conn, "alice", role_privs)
+        assert "SELECT" in result
+        assert "INSERT" in result
+        assert result["SELECT"] == "analyst"
+
+    @patch("app.services.admin.bfs_resolver.get_parent_roles")
+    @patch("app.services.admin.bfs_resolver.get_user_roles")
+    def test_inherited_via_bfs(self, mock_get_user_roles, mock_get_parent_roles):
+        """User's role inherits from a role with privs via BFS upward."""
+        mock_get_user_roles.return_value = ["junior"]
+        # junior's parent is senior, senior is in role_privs
+        mock_get_parent_roles.side_effect = lambda conn, role: {
+            "junior": ["senior"],
+            "senior": [],
+        }.get(role, [])
+        role_privs = {"senior": {"DELETE"}}
+        conn = object()
+        result = _bfs_user_privs(conn, "bob", role_privs)
+        assert "DELETE" in result
+        # source should be the user's direct role (origin)
+        assert result["DELETE"] == "junior"
+
+    @patch("app.services.admin.bfs_resolver.get_user_roles")
+    def test_no_matching_roles(self, mock_get_user_roles):
+        """User has roles but none match role_privs (and no parents)."""
+        mock_get_user_roles.return_value = ["unrelated"]
+        role_privs = {"analyst": {"SELECT"}}
+        conn = object()
+        with patch("app.services.admin.bfs_resolver.get_parent_roles", return_value=[]):
+            result = _bfs_user_privs(conn, "charlie", role_privs)
+        assert result == {}
+
+    @patch("app.services.admin.bfs_resolver.get_user_roles")
+    def test_no_roles_at_all(self, mock_get_user_roles):
+        """User with no roles returns empty."""
+        mock_get_user_roles.return_value = []
+        result = _bfs_user_privs(object(), "nobody", {"admin": {"ALL"}})
+        assert result == {}
+
+    @patch("app.services.admin.bfs_resolver.get_user_roles")
+    def test_first_match_wins(self, mock_get_user_roles):
+        """When multiple roles provide same priv, first match is kept (setdefault)."""
+        mock_get_user_roles.return_value = ["role_a", "role_b"]
+        role_privs = {
+            "role_a": {"SELECT"},
+            "role_b": {"SELECT"},
+        }
+        result = _bfs_user_privs(object(), "dave", role_privs)
+        assert result["SELECT"] == "role_a"
+
+
+# ══════════════════════════════════════════════════════════════════════
+# _finalize
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestFinalize:
+    def _make_query(self, catalog="cat1", database="db1", name="t1", object_type="TABLE"):
+        return ObjectQuery(catalog=catalog, database=database, name=name, object_type=object_type)
+
+    def test_implicit_usage_converted(self):
+        """IMPLICIT_USAGE grants are converted to USAGE with '(implicit)' source."""
+        grant = _grant(grantee="role_a", privilege_type="SELECT", source="direct")
+        q = self._make_query(object_type="DATABASE")
+        classified = [(grant, Relevance.IMPLICIT_USAGE)]
+        result = _finalize(classified, q)
+        assert len(result) == 1
+        assert result[0].privilege_type == "USAGE"
+        assert "(implicit)" in result[0].source
+        assert result[0].grantee == "role_a"
+        assert result[0].object_catalog == "cat1"
+        assert result[0].object_database == "db1"
+
+    def test_implicit_usage_dedup_per_grantee(self):
+        """Multiple IMPLICIT_USAGE grants for the same grantee yield only one USAGE."""
+        g1 = _grant(grantee="role_a", privilege_type="SELECT", source="direct")
+        g2 = _grant(grantee="role_a", privilege_type="INSERT", source="direct")
+        q = self._make_query()
+        classified = [
+            (g1, Relevance.IMPLICIT_USAGE),
+            (g2, Relevance.IMPLICIT_USAGE),
+        ]
+        result = _finalize(classified, q)
+        usage_grants = [g for g in result if g.privilege_type == "USAGE"]
+        assert len(usage_grants) == 1
+
+    def test_regular_grants_pass_through(self):
+        """EXACT grants pass through unchanged."""
+        grant = _grant(privilege_type="SELECT")
+        q = self._make_query()
+        classified = [(grant, Relevance.EXACT)]
+        result = _finalize(classified, q)
+        assert len(result) == 1
+        assert result[0].privilege_type == "SELECT"
+        assert result[0].grantee == "role_a"
+
+    def test_duplicate_grants_deduplicated(self):
+        """Identical grants are deduplicated."""
+        g1 = _grant(privilege_type="SELECT")
+        g2 = _grant(privilege_type="SELECT")
+        q = self._make_query()
+        classified = [(g1, Relevance.EXACT), (g2, Relevance.EXACT)]
+        result = _finalize(classified, q)
+        select_grants = [g for g in result if g.privilege_type == "SELECT"]
+        assert len(select_grants) == 1
+
+    def test_mixed_exact_and_implicit(self):
+        """Mix of EXACT and IMPLICIT_USAGE grants processed correctly."""
+        exact = _grant(grantee="role_a", privilege_type="SELECT")
+        implicit = _grant(grantee="role_b", privilege_type="INSERT", source="inherited")
+        q = self._make_query(object_type="DATABASE")
+        classified = [
+            (exact, Relevance.EXACT),
+            (implicit, Relevance.IMPLICIT_USAGE),
+        ]
+        result = _finalize(classified, q)
+        types = {g.privilege_type for g in result}
+        assert "SELECT" in types
+        assert "USAGE" in types
+        # role_b should have USAGE, not INSERT
+        role_b_grants = [g for g in result if g.grantee == "role_b"]
+        assert all(g.privilege_type == "USAGE" for g in role_b_grants)
+
+    def test_empty_input(self):
+        """Empty classified list yields empty result."""
+        q = self._make_query()
+        result = _finalize([], q)
+        assert result == []
+
+
+# ══════════════════════════════════════════════════════════════════════
+# _find_ancestors_with_grants
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestFindAncestorsWithGrants:
+    @patch("app.services.admin.bfs_resolver.get_parent_roles")
+    def test_finds_parent_with_grants(self, mock_get_parent_roles):
+        """Start from child, find parent that has grants."""
+        mock_get_parent_roles.side_effect = lambda conn, role: {
+            "child": ["parent"],
+            "parent": [],
+        }.get(role, [])
+        grants_map = {"parent": [_grant(grantee="parent")]}
+        result = _find_ancestors_with_grants(object(), "child", grants_map)
+        assert result == ["parent"]
+
+    @patch("app.services.admin.bfs_resolver.get_parent_roles")
+    def test_no_ancestors_with_grants(self, mock_get_parent_roles):
+        """No ancestors have grants."""
+        mock_get_parent_roles.side_effect = lambda conn, role: {
+            "child": ["mid"],
+            "mid": ["top"],
+            "top": [],
+        }.get(role, [])
+        grants_map = {"unrelated": [_grant()]}
+        result = _find_ancestors_with_grants(object(), "child", grants_map)
+        assert result == []
+
+    @patch("app.services.admin.bfs_resolver.get_parent_roles")
+    def test_multiple_ancestors_with_grants(self, mock_get_parent_roles):
+        """Multiple ancestors at different depths have grants."""
+        mock_get_parent_roles.side_effect = lambda conn, role: {
+            "child": ["mid"],
+            "mid": ["top"],
+            "top": [],
+        }.get(role, [])
+        grants_map = {
+            "mid": [_grant(grantee="mid")],
+            "top": [_grant(grantee="top")],
+        }
+        result = _find_ancestors_with_grants(object(), "child", grants_map)
+        assert "mid" in result
+        assert "top" in result
+
+    @patch("app.services.admin.bfs_resolver.get_parent_roles")
+    def test_diamond_ancestor_graph(self, mock_get_parent_roles):
+        """Diamond: child -> A, child -> B, A -> top, B -> top. top has grants."""
+        mock_get_parent_roles.side_effect = lambda conn, role: {
+            "child": ["A", "B"],
+            "A": ["top"],
+            "B": ["top"],
+            "top": [],
+        }.get(role, [])
+        grants_map = {"top": [_grant(grantee="top")]}
+        result = _find_ancestors_with_grants(object(), "child", grants_map)
+        assert result == ["top"]
+
+    @patch("app.services.admin.bfs_resolver.get_parent_roles")
+    def test_start_role_excluded(self, mock_get_parent_roles):
+        """Start role itself should not be included even if it has grants."""
+        mock_get_parent_roles.return_value = []
+        grants_map = {"child": [_grant(grantee="child")]}
+        result = _find_ancestors_with_grants(object(), "child", grants_map)
+        assert result == []
+
+    @patch("app.services.admin.bfs_resolver.get_parent_roles")
+    def test_cycle_protection(self, mock_get_parent_roles):
+        """Cycle in ancestor graph does not cause infinite loop."""
+        mock_get_parent_roles.side_effect = lambda conn, role: {
+            "child": ["A"],
+            "A": ["B"],
+            "B": ["A"],  # cycle
+        }.get(role, [])
+        grants_map = {"A": [_grant(grantee="A")]}
+        result = _find_ancestors_with_grants(object(), "child", grants_map)
+        assert result == ["A"]

--- a/backend/tests/test_grant_classifier.py
+++ b/backend/tests/test_grant_classifier.py
@@ -1,0 +1,631 @@
+"""Unit tests for grant_classifier: ObjectQuery, classify_grant, and helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.schemas import PrivilegeGrant
+from app.services.common.grant_classifier import (
+    ObjectQuery,
+    Relevance,
+    _convert_implicit_usage,
+    _deduplicate,
+    classify_grant,
+)
+
+
+# ─── Helper to build PrivilegeGrant quickly ──────────────────────────
+
+
+def _grant(
+    privilege_type: str = "SELECT",
+    object_type: str = "TABLE",
+    object_catalog: str | None = "cat1",
+    object_database: str | None = "db1",
+    object_name: str | None = "tbl1",
+    grantee: str = "user1",
+    grantee_type: str = "USER",
+    source: str = "direct",
+) -> PrivilegeGrant:
+    return PrivilegeGrant(
+        grantee=grantee,
+        grantee_type=grantee_type,
+        object_catalog=object_catalog,
+        object_database=object_database,
+        object_name=object_name,
+        object_type=object_type,
+        privilege_type=privilege_type,
+        is_grantable=False,
+        source=source,
+    )
+
+
+# =====================================================================
+# 1. ObjectQuery properties
+# =====================================================================
+
+
+class TestObjectQueryProperties:
+    def test_is_system_true(self):
+        q = ObjectQuery(catalog=None, database=None, name=None, object_type="SYSTEM")
+        assert q.is_system is True
+
+    def test_is_system_false_for_table(self):
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert q.is_system is False
+
+    def test_is_system_case_insensitive(self):
+        q = ObjectQuery(catalog=None, database=None, name=None, object_type="system")
+        assert q.is_system is True
+
+    def test_is_scope_query_database_no_name(self):
+        q = ObjectQuery(catalog="c", database="d", name=None, object_type="DATABASE")
+        assert q.is_scope_query is True
+
+    def test_is_scope_query_catalog_no_name(self):
+        q = ObjectQuery(catalog="c", database=None, name=None, object_type="CATALOG")
+        assert q.is_scope_query is True
+
+    def test_is_scope_query_false_when_name_provided(self):
+        q = ObjectQuery(catalog="c", database="d", name="mydb", object_type="DATABASE")
+        assert q.is_scope_query is False
+
+    def test_is_scope_query_false_for_table(self):
+        q = ObjectQuery(catalog="c", database="d", name=None, object_type="TABLE")
+        assert q.is_scope_query is False
+
+    def test_type_upper_with_none(self):
+        q = ObjectQuery(catalog=None, database=None, name=None, object_type=None)
+        assert q.type_upper == ""
+
+    def test_child_types_database(self):
+        q = ObjectQuery(catalog="c", database="d", name=None, object_type="DATABASE")
+        assert q.child_types == frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW", "FUNCTION"})
+
+    def test_child_types_catalog(self):
+        q = ObjectQuery(catalog="c", database=None, name=None, object_type="CATALOG")
+        assert q.child_types == frozenset(
+            {"TABLE", "VIEW", "MATERIALIZED VIEW", "FUNCTION", "DATABASE"}
+        )
+
+    def test_child_types_empty_for_table(self):
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert q.child_types == frozenset()
+
+
+# =====================================================================
+# 2. classify_grant — EXACT matches
+# =====================================================================
+
+
+class TestClassifyGrantExact:
+    def test_table_grant_matches_table_query(self):
+        g = _grant(privilege_type="SELECT", object_type="TABLE",
+                    object_catalog="c", object_database="d", object_name="t")
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.EXACT
+
+    def test_database_grant_matches_database_query(self):
+        g = _grant(privilege_type="USAGE", object_type="DATABASE",
+                    object_catalog="c", object_database="d", object_name="mydb")
+        q = ObjectQuery(catalog="c", database="d", name="mydb", object_type="DATABASE")
+        assert classify_grant(g, q) == Relevance.EXACT
+
+    def test_system_grant_matches_system_query(self):
+        g = _grant(privilege_type="NODE", object_type="SYSTEM",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog=None, database=None, name=None, object_type="SYSTEM")
+        assert classify_grant(g, q) == Relevance.EXACT
+
+    def test_view_grant_matches_view_query(self):
+        g = _grant(privilege_type="SELECT", object_type="VIEW",
+                    object_catalog="c", object_database="d", object_name="v1")
+        q = ObjectQuery(catalog="c", database="d", name="v1", object_type="VIEW")
+        assert classify_grant(g, q) == Relevance.EXACT
+
+    def test_non_object_type_exact_with_name(self):
+        """USER-type grant with matching name is EXACT."""
+        g = _grant(privilege_type="IMPERSONATE", object_type="USER",
+                    object_catalog=None, object_database=None, object_name="alice")
+        q = ObjectQuery(catalog=None, database=None, name="alice", object_type="USER")
+        assert classify_grant(g, q) == Relevance.EXACT
+
+
+# =====================================================================
+# 3. classify_grant — PARENT_SCOPE
+# =====================================================================
+
+
+class TestClassifyGrantParentScope:
+    def test_database_grant_for_table_query(self):
+        """A DATABASE-level grant is PARENT_SCOPE when querying a table in that database."""
+        g = _grant(privilege_type="SELECT", object_type="DATABASE",
+                    object_catalog="c", object_database="d", object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="tbl", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_catalog_grant_for_table_query(self):
+        g = _grant(privilege_type="SELECT", object_type="CATALOG",
+                    object_catalog="c", object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="tbl", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_wildcard_table_grant_parent_scope(self):
+        """Grant on TABLE type with no coordinates is PARENT_SCOPE."""
+        g = _grant(privilege_type="SELECT", object_type="TABLE",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="tbl", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_create_table_on_database_is_parent_scope_for_table(self):
+        """CREATE TABLE privilege on DATABASE is PARENT_SCOPE for TABLE query."""
+        g = _grant(privilege_type="CREATE TABLE", object_type="DATABASE",
+                    object_catalog="c", object_database="d", object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="tbl", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_non_object_type_wildcard_is_parent_scope(self):
+        """USER-type grant without name when querying a specific user is PARENT_SCOPE."""
+        g = _grant(privilege_type="IMPERSONATE", object_type="USER",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog=None, database=None, name="alice", object_type="USER")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_system_create_external_catalog_is_parent_scope(self):
+        """SYSTEM-level CREATE EXTERNAL CATALOG is PARENT_SCOPE for CATALOG query."""
+        g = _grant(privilege_type="CREATE EXTERNAL CATALOG", object_type="SYSTEM",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database=None, name=None, object_type="CATALOG")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_system_create_warehouse_is_parent_scope(self):
+        g = _grant(privilege_type="CREATE WAREHOUSE", object_type="SYSTEM",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog=None, database=None, name=None, object_type="WAREHOUSE")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+
+# =====================================================================
+# 4. classify_grant — IMPLICIT_USAGE
+# =====================================================================
+
+
+class TestClassifyGrantImplicitUsage:
+    def test_table_grant_implicit_usage_on_database_scope_query(self):
+        """TABLE grant triggers IMPLICIT_USAGE when querying DATABASE scope (no name)."""
+        g = _grant(privilege_type="SELECT", object_type="TABLE",
+                    object_catalog="c", object_database="d", object_name="tbl")
+        q = ObjectQuery(catalog="c", database="d", name=None, object_type="DATABASE")
+        assert classify_grant(g, q) == Relevance.IMPLICIT_USAGE
+
+    def test_view_grant_implicit_usage_on_database_scope_query(self):
+        g = _grant(privilege_type="SELECT", object_type="VIEW",
+                    object_catalog="c", object_database="d", object_name="v1")
+        q = ObjectQuery(catalog="c", database="d", name=None, object_type="DATABASE")
+        assert classify_grant(g, q) == Relevance.IMPLICIT_USAGE
+
+    def test_function_grant_implicit_usage_on_database_scope_query(self):
+        g = _grant(privilege_type="USAGE", object_type="FUNCTION",
+                    object_catalog="c", object_database="d", object_name="fn1")
+        q = ObjectQuery(catalog="c", database="d", name=None, object_type="DATABASE")
+        assert classify_grant(g, q) == Relevance.IMPLICIT_USAGE
+
+    def test_database_grant_implicit_usage_on_catalog_scope_query(self):
+        """DATABASE grant triggers IMPLICIT_USAGE when querying CATALOG scope."""
+        g = _grant(privilege_type="USAGE", object_type="DATABASE",
+                    object_catalog="c", object_database="d", object_name="mydb")
+        q = ObjectQuery(catalog="c", database=None, name=None, object_type="CATALOG")
+        assert classify_grant(g, q) == Relevance.IMPLICIT_USAGE
+
+    def test_no_implicit_usage_when_catalog_mismatches(self):
+        g = _grant(privilege_type="SELECT", object_type="TABLE",
+                    object_catalog="other_cat", object_database="d", object_name="tbl")
+        q = ObjectQuery(catalog="c", database="d", name=None, object_type="DATABASE")
+        # scope_matches fails on catalog mismatch, so not IMPLICIT_USAGE
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+
+# =====================================================================
+# 5. classify_grant — IRRELEVANT
+# =====================================================================
+
+
+class TestClassifyGrantIrrelevant:
+    def test_unrelated_catalog(self):
+        g = _grant(privilege_type="SELECT", object_type="TABLE",
+                    object_catalog="other", object_database="d", object_name="t")
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_unrelated_database(self):
+        g = _grant(privilege_type="SELECT", object_type="TABLE",
+                    object_catalog="c", object_database="other", object_name="t")
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_unrelated_name(self):
+        g = _grant(privilege_type="SELECT", object_type="TABLE",
+                    object_catalog="c", object_database="d", object_name="other")
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_system_only_priv_irrelevant_for_table(self):
+        """A SYSTEM-only privilege like NODE is IRRELEVANT for table queries."""
+        g = _grant(privilege_type="NODE", object_type="SYSTEM",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_non_system_grant_for_system_query(self):
+        """A TABLE grant is IRRELEVANT for SYSTEM query."""
+        g = _grant(privilege_type="SELECT", object_type="TABLE",
+                    object_catalog="c", object_database="d", object_name="t")
+        q = ObjectQuery(catalog=None, database=None, name=None, object_type="SYSTEM")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_db_only_priv_irrelevant_for_wrong_type(self):
+        """CREATE VIEW on DATABASE is IRRELEVANT when querying a TABLE."""
+        g = _grant(privilege_type="CREATE VIEW", object_type="DATABASE",
+                    object_catalog="c", object_database="d", object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="tbl", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_non_object_type_mismatch(self):
+        """A RESOURCE GROUP grant is IRRELEVANT for USER query."""
+        g = _grant(privilege_type="USAGE", object_type="RESOURCE GROUP",
+                    object_catalog=None, object_database=None, object_name="rg1")
+        q = ObjectQuery(catalog=None, database=None, name="alice", object_type="USER")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_table_wildcard_irrelevant_for_view_query(self):
+        """A wildcard TABLE grant is IRRELEVANT when querying VIEW type."""
+        g = _grant(privilege_type="SELECT", object_type="TABLE",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="v1", object_type="VIEW")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_view_wildcard_irrelevant_for_table_query(self):
+        g = _grant(privilege_type="SELECT", object_type="VIEW",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_system_grant_type_irrelevant_for_non_system_query(self):
+        """SYSTEM otype with a system-only priv is IRRELEVANT for TABLE query."""
+        g = _grant(privilege_type="OPERATE", object_type="SYSTEM",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_named_grant_type_mismatch_via_wildcard_map(self):
+        """A named VIEW grant is IRRELEVANT for TABLE query (type mismatch)."""
+        g = _grant(privilege_type="SELECT", object_type="VIEW",
+                    object_catalog="c", object_database="d", object_name="v1")
+        q = ObjectQuery(catalog="c", database="d", name="v1", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+
+# =====================================================================
+# 6. classify_grant — SYSTEM scope
+# =====================================================================
+
+
+class TestClassifyGrantSystem:
+    def test_system_exact(self):
+        g = _grant(privilege_type="GRANT", object_type="SYSTEM",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog=None, database=None, name=None, object_type="SYSTEM")
+        assert classify_grant(g, q) == Relevance.EXACT
+
+    def test_all_system_only_privs_irrelevant_for_table(self):
+        """Every system-only privilege is IRRELEVANT for non-SYSTEM queries."""
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        for priv in ["NODE", "BLACKLIST", "FILE", "OPERATE", "PLUGIN",
+                      "CREATE RESOURCE GROUP", "GRANT", "SECURITY"]:
+            g = _grant(privilege_type=priv, object_type="SYSTEM",
+                        object_catalog=None, object_database=None, object_name=None)
+            assert classify_grant(g, q) == Relevance.IRRELEVANT, f"Failed for {priv}"
+
+    def test_system_create_maps_to_target_type(self):
+        """CREATE RESOURCE GROUP on SYSTEM is PARENT_SCOPE for RESOURCE GROUP query."""
+        g = _grant(privilege_type="CREATE RESOURCE GROUP", object_type="SYSTEM",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog=None, database=None, name=None, object_type="RESOURCE GROUP")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_system_create_resource_maps_correctly(self):
+        g = _grant(privilege_type="CREATE RESOURCE", object_type="SYSTEM",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog=None, database=None, name=None, object_type="RESOURCE")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_system_create_global_function_maps_correctly(self):
+        g = _grant(privilege_type="CREATE GLOBAL FUNCTION", object_type="SYSTEM",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog=None, database=None, name=None, object_type="GLOBAL FUNCTION")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_system_create_storage_volume_maps_correctly(self):
+        g = _grant(privilege_type="CREATE STORAGE VOLUME", object_type="SYSTEM",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog=None, database=None, name=None, object_type="STORAGE VOLUME")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+
+# =====================================================================
+# 7. classify_grant — wildcard grants
+# =====================================================================
+
+
+class TestClassifyGrantWildcards:
+    def test_wildcard_table_for_table_query(self):
+        g = _grant(privilege_type="SELECT", object_type="TABLE",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_wildcard_database_for_table_query(self):
+        """Wildcard DATABASE grant covers TABLE query via _WILDCARD_TYPE_MAP."""
+        g = _grant(privilege_type="SELECT", object_type="DATABASE",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_wildcard_catalog_for_table_query(self):
+        g = _grant(privilege_type="SELECT", object_type="CATALOG",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_wildcard_view_irrelevant_for_table(self):
+        g = _grant(privilege_type="SELECT", object_type="VIEW",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_wildcard_mv_for_mv_query(self):
+        g = _grant(privilege_type="SELECT", object_type="MATERIALIZED VIEW",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="mv1", object_type="MATERIALIZED VIEW")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_wildcard_no_type_for_any_query(self):
+        """A grant with no coordinates and no otype falls through to scope matching."""
+        g = _grant(privilege_type="ALL", object_type="",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        # otype is empty string, not in _NON_OBJECT_TYPES, not SYSTEM
+        # gc/gd/gn are all None, otype is falsy → skips wildcard block (requires otype)
+        # Falls through to _scope_matches (all None coords match) → PARENT_SCOPE with no gn
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_wildcard_grant_no_name_in_grant_for_scope_query(self):
+        """Wildcard TABLE grant (no catalog, no db, no name) → PARENT_SCOPE for TABLE with name."""
+        g = _grant(privilege_type="DROP", object_type="TABLE",
+                    object_catalog=None, object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+
+# =====================================================================
+# 8. _convert_implicit_usage
+# =====================================================================
+
+
+class TestConvertImplicitUsage:
+    def test_converts_child_grants_to_usage(self):
+        q = ObjectQuery(catalog="c", database="d", name=None, object_type="DATABASE")
+        grants = [
+            _grant(privilege_type="SELECT", object_type="TABLE",
+                   object_catalog="c", object_database="d", object_name="t1",
+                   grantee="user1", source="direct"),
+            _grant(privilege_type="INSERT", object_type="TABLE",
+                   object_catalog="c", object_database="d", object_name="t2",
+                   grantee="user2", source="role1"),
+        ]
+        result = _convert_implicit_usage(grants, q)
+        assert len(result) == 2
+        assert result[0].privilege_type == "USAGE"
+        assert result[0].object_type == "DATABASE"
+        assert result[0].grantee == "user1"
+        assert result[0].source == "direct (implicit)"
+        assert result[1].grantee == "user2"
+        assert result[1].source == "role1 (implicit)"
+
+    def test_deduplicates_by_grantee(self):
+        """Same grantee with multiple child grants → only one USAGE."""
+        q = ObjectQuery(catalog="c", database="d", name=None, object_type="DATABASE")
+        grants = [
+            _grant(privilege_type="SELECT", object_type="TABLE",
+                   object_catalog="c", object_database="d", object_name="t1",
+                   grantee="user1"),
+            _grant(privilege_type="INSERT", object_type="TABLE",
+                   object_catalog="c", object_database="d", object_name="t2",
+                   grantee="user1"),
+        ]
+        result = _convert_implicit_usage(grants, q)
+        assert len(result) == 1
+        assert result[0].privilege_type == "USAGE"
+
+    def test_preserves_non_child_grants(self):
+        q = ObjectQuery(catalog="c", database="d", name=None, object_type="DATABASE")
+        db_grant = _grant(privilege_type="USAGE", object_type="DATABASE",
+                          object_catalog="c", object_database="d", object_name=None,
+                          grantee="user1")
+        grants = [db_grant]
+        result = _convert_implicit_usage(grants, q)
+        assert len(result) == 1
+        assert result[0].privilege_type == "USAGE"
+        assert result[0].source == "direct"  # not modified
+
+    def test_noop_when_not_scope_query(self):
+        """Returns input unchanged when query is not a scope query."""
+        q = ObjectQuery(catalog="c", database="d", name="tbl", object_type="TABLE")
+        grants = [_grant()]
+        result = _convert_implicit_usage(grants, q)
+        assert result is grants  # same object, no transformation
+
+    def test_catalog_scope_converts_database_grants(self):
+        q = ObjectQuery(catalog="c", database=None, name=None, object_type="CATALOG")
+        grants = [
+            _grant(privilege_type="USAGE", object_type="DATABASE",
+                   object_catalog="c", object_database="d", object_name="mydb",
+                   grantee="user1", source="direct"),
+        ]
+        result = _convert_implicit_usage(grants, q)
+        assert len(result) == 1
+        assert result[0].privilege_type == "USAGE"
+        assert result[0].object_type == "CATALOG"
+        assert result[0].source == "direct (implicit)"
+
+    def test_empty_list(self):
+        q = ObjectQuery(catalog="c", database="d", name=None, object_type="DATABASE")
+        result = _convert_implicit_usage([], q)
+        assert result == []
+
+
+# =====================================================================
+# 9. _deduplicate
+# =====================================================================
+
+
+class TestDeduplicate:
+    def test_removes_exact_duplicates(self):
+        g1 = _grant(privilege_type="SELECT", grantee="u1")
+        g2 = _grant(privilege_type="SELECT", grantee="u1")
+        result = _deduplicate([g1, g2])
+        assert len(result) == 1
+
+    def test_keeps_different_privileges(self):
+        g1 = _grant(privilege_type="SELECT", grantee="u1")
+        g2 = _grant(privilege_type="INSERT", grantee="u1")
+        result = _deduplicate([g1, g2])
+        assert len(result) == 2
+
+    def test_keeps_different_grantees(self):
+        g1 = _grant(privilege_type="SELECT", grantee="u1")
+        g2 = _grant(privilege_type="SELECT", grantee="u2")
+        result = _deduplicate([g1, g2])
+        assert len(result) == 2
+
+    def test_keeps_different_grantee_types(self):
+        g1 = _grant(privilege_type="SELECT", grantee="admin", grantee_type="USER")
+        g2 = _grant(privilege_type="SELECT", grantee="admin", grantee_type="ROLE")
+        result = _deduplicate([g1, g2])
+        assert len(result) == 2
+
+    def test_none_values_treated_as_empty_string(self):
+        """Grants with None vs empty-string in optional fields are deduplicated together."""
+        g1 = _grant(object_catalog=None, object_database=None, object_name=None)
+        g2 = _grant(object_catalog=None, object_database=None, object_name=None)
+        result = _deduplicate([g1, g2])
+        assert len(result) == 1
+
+    def test_preserves_order_first_wins(self):
+        g1 = _grant(privilege_type="SELECT", grantee="u1", source="role_a")
+        g2 = _grant(privilege_type="SELECT", grantee="u1", source="role_b")
+        result = _deduplicate([g1, g2])
+        assert len(result) == 1
+        assert result[0].source == "role_a"  # first one kept
+
+    def test_empty_list(self):
+        assert _deduplicate([]) == []
+
+    def test_different_object_types_kept(self):
+        g1 = _grant(object_type="TABLE")
+        g2 = _grant(object_type="VIEW")
+        result = _deduplicate([g1, g2])
+        assert len(result) == 2
+
+
+# =====================================================================
+# 10. Edge cases
+# =====================================================================
+
+
+class TestEdgeCases:
+    def test_none_object_type_in_grant(self):
+        """Grant with None object_type does not crash."""
+        g = _grant(privilege_type="SELECT", object_type="",
+                    object_catalog="c", object_database="d", object_name="t")
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        result = classify_grant(g, q)
+        # Empty otype → not SYSTEM, not in _NON_OBJECT_TYPES, falls through to scope match
+        assert result in (Relevance.EXACT, Relevance.PARENT_SCOPE, Relevance.IRRELEVANT)
+
+    def test_empty_string_privilege(self):
+        g = _grant(privilege_type="", object_type="TABLE",
+                    object_catalog="c", object_database="d", object_name="t")
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        # Should not crash; empty priv is not in any special set
+        assert classify_grant(g, q) == Relevance.EXACT
+
+    def test_function_name_normalization_in_non_object_type(self):
+        """Function signature in name is normalized: fn(VARCHAR) matches fn."""
+        g = _grant(privilege_type="USAGE", object_type="GLOBAL FUNCTION",
+                    object_catalog=None, object_database=None, object_name="myfn(VARCHAR)")
+        q = ObjectQuery(catalog=None, database=None, name="myfn", object_type="GLOBAL FUNCTION")
+        assert classify_grant(g, q) == Relevance.EXACT
+
+    def test_function_name_normalization_mismatch(self):
+        g = _grant(privilege_type="USAGE", object_type="GLOBAL FUNCTION",
+                    object_catalog=None, object_database=None, object_name="otherfn(INT)")
+        q = ObjectQuery(catalog=None, database=None, name="myfn", object_type="GLOBAL FUNCTION")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_case_insensitive_object_type(self):
+        """Grant with lowercase object_type is handled correctly."""
+        g = _grant(privilege_type="SELECT", object_type="table",
+                    object_catalog="c", object_database="d", object_name="t")
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.EXACT
+
+    def test_objectquery_frozen(self):
+        """ObjectQuery is immutable (frozen dataclass)."""
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        with pytest.raises(AttributeError):
+            q.catalog = "other"  # type: ignore[misc]
+
+    def test_mixed_scope_and_non_child_grant(self):
+        """DATABASE scope query ignores CATALOG-type grants (not a child type)."""
+        g = _grant(privilege_type="USAGE", object_type="CATALOG",
+                    object_catalog="c", object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name=None, object_type="DATABASE")
+        # CATALOG is not in DATABASE's child_types, so not IMPLICIT_USAGE
+        # Falls through to wildcard check or scope match
+        result = classify_grant(g, q)
+        assert result != Relevance.IMPLICIT_USAGE
+
+    def test_create_view_parent_scope_for_view_query(self):
+        """CREATE VIEW on DATABASE is PARENT_SCOPE for VIEW query."""
+        g = _grant(privilege_type="CREATE VIEW", object_type="DATABASE",
+                    object_catalog="c", object_database="d", object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="v1", object_type="VIEW")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_create_materialized_view_parent_scope(self):
+        g = _grant(privilege_type="CREATE MATERIALIZED VIEW", object_type="DATABASE",
+                    object_catalog="c", object_database="d", object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="mv1",
+                        object_type="MATERIALIZED VIEW")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_create_function_parent_scope(self):
+        g = _grant(privilege_type="CREATE FUNCTION", object_type="DATABASE",
+                    object_catalog="c", object_database="d", object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="fn1", object_type="FUNCTION")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+    def test_create_masking_policy_irrelevant_for_table(self):
+        """CREATE MASKING POLICY (DB-only priv, not in _CREATE_TYPE_MAP) is IRRELEVANT for TABLE."""
+        g = _grant(privilege_type="CREATE MASKING POLICY", object_type="DATABASE",
+                    object_catalog="c", object_database="d", object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+    def test_grant_with_only_catalog_matching(self):
+        """Grant specifying only catalog matches query in that catalog."""
+        g = _grant(privilege_type="USAGE", object_type="CATALOG",
+                    object_catalog="c", object_database=None, object_name=None)
+        q = ObjectQuery(catalog="c", database="d", name="t", object_type="TABLE")
+        assert classify_grant(g, q) == Relevance.PARENT_SCOPE

--- a/backend/tests/test_grant_parser.py
+++ b/backend/tests/test_grant_parser.py
@@ -1,0 +1,576 @@
+"""Unit tests for app.services.common.grant_parser module."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.models.schemas import PrivilegeGrant
+from app.services.common.grant_parser import (
+    _parse_grant_statement,
+    _parse_show_grants,
+    _row_to_grants,
+)
+
+
+# ────────────────────────────────────────────
+# Helpers
+# ────────────────────────────────────────────
+
+def _single(grants: list[PrivilegeGrant]) -> PrivilegeGrant:
+    """Assert exactly one grant returned and return it."""
+    assert len(grants) == 1, f"Expected 1 grant, got {len(grants)}: {grants}"
+    return grants[0]
+
+
+# ════════════════════════════════════════════
+# _parse_grant_statement
+# ════════════════════════════════════════════
+
+
+class TestParseGrantStatement:
+    """Tests for _parse_grant_statement (pure function)."""
+
+    # ── Simple TABLE grant ──
+
+    def test_simple_table_grant(self):
+        stmt = "GRANT SELECT ON TABLE default_catalog.db.tbl TO USER 'alice'"
+        g = _single(_parse_grant_statement(stmt, "alice", "USER"))
+        assert g.privilege_type == "SELECT"
+        assert g.object_type == "TABLE"
+        assert g.object_catalog == "default_catalog"
+        assert g.object_database == "db"
+        assert g.object_name == "tbl"
+        assert g.grantee == "alice"
+        assert g.grantee_type == "USER"
+
+    # ── Multi-privilege ──
+
+    def test_multi_privilege(self):
+        stmt = "GRANT SELECT, INSERT ON TABLE default_catalog.db.tbl TO USER 'alice'"
+        grants = _parse_grant_statement(stmt, "alice", "USER")
+        assert len(grants) == 2
+        privs = {g.privilege_type for g in grants}
+        assert privs == {"SELECT", "INSERT"}
+        for g in grants:
+            assert g.object_type == "TABLE"
+            assert g.object_catalog == "default_catalog"
+            assert g.object_database == "db"
+            assert g.object_name == "tbl"
+
+    # ── DATABASE scope ──
+
+    def test_database_scope(self):
+        stmt = "GRANT USAGE ON DATABASE db1 TO ROLE 'analyst'"
+        g = _single(_parse_grant_statement(stmt, "analyst", "ROLE"))
+        assert g.privilege_type == "USAGE"
+        assert g.object_type == "DATABASE"
+        # "ON DATABASE db1" → db1 is the database, NOT the catalog
+        assert g.object_database == "db1"
+        assert g.object_catalog is None
+        assert g.object_name is None
+
+    # ── CATALOG scope ──
+
+    def test_catalog_scope(self):
+        stmt = "GRANT USAGE ON CATALOG default_catalog TO ROLE 'analyst'"
+        g = _single(_parse_grant_statement(stmt, "analyst", "ROLE"))
+        assert g.privilege_type == "USAGE"
+        assert g.object_type == "CATALOG"
+        assert g.object_catalog == "default_catalog"
+        assert g.object_database is None
+        assert g.object_name is None
+
+    # ── SYSTEM scope ──
+
+    def test_system_scope(self):
+        stmt = "GRANT GRANT ON SYSTEM TO ROLE 'root'"
+        g = _single(_parse_grant_statement(stmt, "root", "ROLE"))
+        assert g.privilege_type == "GRANT"
+        assert g.object_type == "SYSTEM"
+
+    # ── MATERIALIZED VIEW (multi-word type) ──
+
+    def test_materialized_view_3part(self):
+        stmt = "GRANT SELECT ON MATERIALIZED VIEW cat.db.mv1 TO USER 'alice'"
+        g = _single(_parse_grant_statement(stmt, "alice", "USER"))
+        assert g.privilege_type == "SELECT"
+        assert g.object_type == "MATERIALIZED VIEW"
+        # 3-part path: catalog.database.name
+        assert g.object_catalog == "cat"
+        assert g.object_database == "db"
+        assert g.object_name == "mv1"
+
+    def test_materialized_view_2part(self):
+        stmt = "GRANT SELECT ON MATERIALIZED VIEW db.mv1 TO USER 'alice'"
+        g = _single(_parse_grant_statement(stmt, "alice", "USER"))
+        assert g.object_type == "MATERIALIZED VIEW"
+        # 2-part for MATERIALIZED VIEW (object-level) → database.name
+        assert g.object_catalog is None
+        assert g.object_database == "db"
+        assert g.object_name == "mv1"
+
+    # ── STORAGE VOLUME ──
+
+    def test_storage_volume(self):
+        stmt = "GRANT USAGE ON STORAGE VOLUME sv1 TO ROLE 'public'"
+        g = _single(_parse_grant_statement(stmt, "public", "ROLE"))
+        assert g.privilege_type == "USAGE"
+        assert g.object_type == "STORAGE VOLUME"
+        # System-level object: name should be preserved, no catalog
+        assert g.object_name == "sv1"
+        assert g.object_catalog is None
+
+    # ── RESOURCE GROUP ──
+
+    def test_resource_group(self):
+        stmt = "GRANT USAGE ON RESOURCE GROUP rg1 TO USER 'bob'"
+        g = _single(_parse_grant_statement(stmt, "bob", "USER"))
+        assert g.privilege_type == "USAGE"
+        assert g.object_type == "RESOURCE GROUP"
+        assert g.object_name == "rg1"
+        assert g.object_catalog is None
+
+    # ── GLOBAL FUNCTION ──
+
+    def test_global_function(self):
+        stmt = "GRANT USAGE ON GLOBAL FUNCTION gfn_mask_email(VARCHAR(65533)) TO ROLE 'r'"
+        g = _single(_parse_grant_statement(stmt, "r", "ROLE"))
+        assert g.object_type == "GLOBAL FUNCTION"
+        assert g.object_name == "gfn_mask_email(VARCHAR(65533))"
+        assert g.object_catalog is None
+
+    # ── ALL TABLES IN DATABASE (wildcard) ──
+
+    def test_wildcard_all_tables_in_database(self):
+        stmt = "GRANT SELECT ON ALL TABLES IN DATABASE db1 TO ROLE 'analyst'"
+        g = _single(_parse_grant_statement(stmt, "analyst", "ROLE"))
+        assert g.privilege_type == "SELECT"
+        assert g.object_type == "TABLE"
+        assert g.object_database == "db1"
+        assert g.object_catalog is None
+
+    def test_wildcard_all_views_in_database(self):
+        stmt = "GRANT SELECT ON ALL VIEWS IN DATABASE db1 TO ROLE 'analyst'"
+        g = _single(_parse_grant_statement(stmt, "analyst", "ROLE"))
+        assert g.object_type == "VIEW"
+        assert g.object_database == "db1"
+
+    def test_wildcard_all_materialized_views_in_database(self):
+        stmt = "GRANT SELECT ON ALL MATERIALIZED VIEWS IN DATABASE mydb TO ROLE 'r'"
+        g = _single(_parse_grant_statement(stmt, "r", "ROLE"))
+        assert g.object_type == "MATERIALIZED VIEW"
+        assert g.object_database == "mydb"
+
+    def test_wildcard_all_tables_in_all_databases(self):
+        stmt = "GRANT SELECT ON ALL TABLES IN ALL DATABASES TO ROLE 'analyst'"
+        g = _single(_parse_grant_statement(stmt, "analyst", "ROLE"))
+        assert g.object_type == "TABLE"
+        assert g.object_database is None
+
+    # ── FUNCTION with signature ──
+
+    def test_function_with_signature(self):
+        stmt = "GRANT USAGE ON FUNCTION db.fn(INT, VARCHAR) TO ROLE 'r'"
+        grants = _parse_grant_statement(stmt, "r", "ROLE")
+        g = _single(grants)
+        assert g.object_type == "FUNCTION"
+        assert g.privilege_type == "USAGE"
+        # The regex parses "FUNCTION db.fn(INT," as type+path,
+        # but the key point is it doesn't crash and produces a grant
+
+    # ── WITH GRANT OPTION ──
+
+    def test_with_grant_option_does_not_break_parsing(self):
+        # WITH GRANT OPTION appears after the TO clause, so it shouldn't
+        # affect the ON...TO parsing. The regex stops at TO.
+        stmt = "GRANT SELECT ON TABLE default_catalog.db.tbl TO USER 'alice' WITH GRANT OPTION"
+        g = _single(_parse_grant_statement(stmt, "alice", "USER"))
+        assert g.privilege_type == "SELECT"
+        assert g.object_type == "TABLE"
+        assert g.object_catalog == "default_catalog"
+        assert g.object_database == "db"
+        assert g.object_name == "tbl"
+
+    # ── Invalid / unrecognized statements ──
+
+    def test_invalid_statement_returns_empty(self):
+        assert _parse_grant_statement("SELECT 1", "alice", "USER") == []
+
+    def test_empty_string_returns_empty(self):
+        assert _parse_grant_statement("", "alice", "USER") == []
+
+    def test_revoke_returns_empty(self):
+        assert _parse_grant_statement("REVOKE SELECT ON TABLE t FROM USER 'alice'", "alice", "USER") == []
+
+    def test_partial_grant_no_on_returns_empty(self):
+        assert _parse_grant_statement("GRANT SELECT TO USER 'alice'", "alice", "USER") == []
+
+    # ── Backtick-quoted identifiers ──
+
+    def test_backtick_identifiers(self):
+        stmt = "GRANT SELECT ON TABLE `default_catalog`.`my-db`.`my-table` TO USER 'alice'"
+        g = _single(_parse_grant_statement(stmt, "alice", "USER"))
+        assert g.object_catalog == "default_catalog"
+        assert g.object_database == "my-db"
+        assert g.object_name == "my-table"
+
+    # ── Wildcard paths ──
+
+    def test_wildcard_star_path(self):
+        stmt = "GRANT SELECT ON TABLE *.*.* TO USER 'alice'"
+        g = _single(_parse_grant_statement(stmt, "alice", "USER"))
+        assert g.object_type == "TABLE"
+        assert g.object_catalog is None
+        assert g.object_database is None
+        assert g.object_name is None
+
+    def test_catalog_star_database(self):
+        stmt = "GRANT USAGE ON DATABASE cat.* TO ROLE 'r'"
+        g = _single(_parse_grant_statement(stmt, "r", "ROLE"))
+        assert g.object_type == "DATABASE"
+        # For DATABASE type, 2-part path → catalog.database; but DATABASE swaps
+        # Actually: parts=["cat","*"], DATABASE is not in _OBJECT_LEVEL_TYPES,
+        # so catalog=cat, database=None (since *→None)
+        # Then the "ON DATABASE X" swap fires only if catalog and not database:
+        # catalog="cat", database=None → swap → database="cat", catalog=None
+        assert g.object_database == "cat"
+        assert g.object_catalog is None
+
+    # ── VIEW (single-word type) ──
+
+    def test_view_grant(self):
+        stmt = "GRANT SELECT ON VIEW default_catalog.db.v1 TO USER 'alice'"
+        g = _single(_parse_grant_statement(stmt, "alice", "USER"))
+        assert g.object_type == "VIEW"
+        assert g.object_catalog == "default_catalog"
+        assert g.object_database == "db"
+        assert g.object_name == "v1"
+
+    # ── Case insensitivity ──
+
+    def test_case_insensitive(self):
+        stmt = "grant select on table default_catalog.db.tbl to user 'alice'"
+        g = _single(_parse_grant_statement(stmt, "alice", "USER"))
+        assert g.privilege_type == "select"
+        assert g.object_type == "TABLE"
+
+    # ── 1-part path for CATALOG ──
+
+    def test_catalog_1part(self):
+        stmt = "GRANT CREATE DATABASE ON CATALOG mycat TO ROLE 'r'"
+        g = _single(_parse_grant_statement(stmt, "r", "ROLE"))
+        assert g.object_type == "CATALOG"
+        assert g.object_catalog == "mycat"
+        assert g.object_database is None
+
+    # ── WAREHOUSE (system-level object) ──
+
+    def test_warehouse(self):
+        stmt = "GRANT USAGE ON WAREHOUSE wh1 TO ROLE 'r'"
+        g = _single(_parse_grant_statement(stmt, "r", "ROLE"))
+        assert g.object_type == "WAREHOUSE"
+        assert g.object_name == "wh1"
+        assert g.object_catalog is None
+
+    # ── RESOURCE ──
+
+    def test_resource(self):
+        stmt = "GRANT USAGE ON RESOURCE spark_res TO ROLE 'r'"
+        g = _single(_parse_grant_statement(stmt, "r", "ROLE"))
+        assert g.object_type == "RESOURCE"
+        assert g.object_name == "spark_res"
+        assert g.object_catalog is None
+
+    # ── ALL CATALOGS ──
+
+    def test_all_simple_catalogs(self):
+        stmt = "GRANT USAGE ON ALL CATALOGS TO ROLE 'public'"
+        g = _single(_parse_grant_statement(stmt, "public", "ROLE"))
+        assert g.object_type == "CATALOG"
+
+    # ── MASKING POLICY → POLICY ──
+
+    def test_masking_policy(self):
+        stmt = "GRANT APPLY ON MASKING POLICY mp1 TO ROLE 'r'"
+        g = _single(_parse_grant_statement(stmt, "r", "ROLE"))
+        assert g.object_type == "POLICY"
+
+    # ── ROW ACCESS POLICY ──
+    # Note: "ROW ACCESS POLICY" is not in _MULTI_WORD_TYPES, so the regex
+    # captures only "ROW" as the type. The "ROW ACCESS" check in the
+    # normalizer doesn't fire because obj_type is just "ROW".
+    # This documents current behavior; if support is added later, update this test.
+
+    def test_row_access_policy_current_behavior(self):
+        stmt = "GRANT APPLY ON ROW ACCESS POLICY rap1 TO ROLE 'r'"
+        grants = _parse_grant_statement(stmt, "r", "ROLE")
+        g = _single(grants)
+        # Currently parsed as "ROW" type (not "POLICY") due to missing multi-word support
+        assert g.object_type == "ROW"
+
+
+# ════════════════════════════════════════════
+# _row_to_grants
+# ════════════════════════════════════════════
+
+
+class TestRowToGrants:
+    """Tests for _row_to_grants (sys.grants_to_* row dict → PrivilegeGrant list)."""
+
+    def test_standard_row(self):
+        row = {
+            "GRANTEE": "alice",
+            "OBJECT_CATALOG": "default_catalog",
+            "OBJECT_DATABASE": "analytics_db",
+            "OBJECT_NAME": "user_events",
+            "OBJECT_TYPE": "TABLE",
+            "PRIVILEGE_TYPE": "SELECT",
+            "IS_GRANTABLE": "YES",
+        }
+        g = _single(_row_to_grants(row, "USER"))
+        assert g.grantee == "alice"
+        assert g.grantee_type == "USER"
+        assert g.object_catalog == "default_catalog"
+        assert g.object_database == "analytics_db"
+        assert g.object_name == "user_events"
+        assert g.object_type == "TABLE"
+        assert g.privilege_type == "SELECT"
+        assert g.is_grantable is True
+
+    def test_lowercase_keys(self):
+        row = {
+            "grantee": "bob",
+            "object_catalog": "cat1",
+            "object_database": "db1",
+            "object_name": "t1",
+            "object_type": "TABLE",
+            "privilege_type": "INSERT",
+            "is_grantable": "NO",
+        }
+        g = _single(_row_to_grants(row, "USER"))
+        assert g.grantee == "bob"
+        assert g.object_catalog == "cat1"
+        assert g.privilege_type == "INSERT"
+        assert g.is_grantable is False
+
+    def test_comma_separated_privileges(self):
+        row = {
+            "GRANTEE": "alice",
+            "OBJECT_CATALOG": "default_catalog",
+            "OBJECT_DATABASE": "db",
+            "OBJECT_NAME": "tbl",
+            "OBJECT_TYPE": "TABLE",
+            "PRIVILEGE_TYPE": "SELECT,INSERT",
+            "IS_GRANTABLE": "NO",
+        }
+        grants = _row_to_grants(row, "USER")
+        assert len(grants) == 2
+        privs = {g.privilege_type for g in grants}
+        assert privs == {"SELECT", "INSERT"}
+        # All share the same object info
+        for g in grants:
+            assert g.object_catalog == "default_catalog"
+            assert g.object_database == "db"
+            assert g.object_name == "tbl"
+
+    def test_comma_separated_with_spaces(self):
+        row = {
+            "GRANTEE": "alice",
+            "OBJECT_TYPE": "TABLE",
+            "PRIVILEGE_TYPE": " SELECT , INSERT , DELETE ",
+            "IS_GRANTABLE": "NO",
+        }
+        grants = _row_to_grants(row, "USER")
+        assert len(grants) == 3
+        privs = {g.privilege_type for g in grants}
+        assert privs == {"SELECT", "INSERT", "DELETE"}
+
+    def test_none_fields(self):
+        row = {
+            "GRANTEE": "alice",
+            "OBJECT_CATALOG": None,
+            "OBJECT_DATABASE": None,
+            "OBJECT_NAME": None,
+            "OBJECT_TYPE": "SYSTEM",
+            "PRIVILEGE_TYPE": "GRANT",
+            "IS_GRANTABLE": None,
+        }
+        g = _single(_row_to_grants(row, "ROLE"))
+        assert g.object_catalog is None
+        assert g.object_database is None
+        assert g.object_name is None
+        assert g.object_type == "SYSTEM"
+        assert g.is_grantable is False  # None → not "YES"
+
+    def test_missing_keys_defaults(self):
+        row = {}  # completely empty
+        grants = _row_to_grants(row, "USER")
+        g = _single(grants)
+        assert g.grantee == ""
+        assert g.object_catalog is None
+        assert g.object_database is None
+        assert g.object_name is None
+        assert g.object_type == ""
+        assert g.privilege_type == ""
+        assert g.is_grantable is False
+
+    def test_grantee_type_passed_through(self):
+        row = {
+            "GRANTEE": "analyst_role",
+            "OBJECT_TYPE": "TABLE",
+            "PRIVILEGE_TYPE": "SELECT",
+            "IS_GRANTABLE": "NO",
+        }
+        g = _single(_row_to_grants(row, "ROLE"))
+        assert g.grantee_type == "ROLE"
+
+
+# ════════════════════════════════════════════
+# _parse_show_grants
+# ════════════════════════════════════════════
+
+
+class TestParseShowGrants:
+    """Tests for _parse_show_grants (mocked connection)."""
+
+    @patch("app.services.common.grant_parser.execute_query")
+    def test_user_show_grants(self, mock_exec):
+        mock_exec.return_value = [
+            {
+                "Catalog": "default_catalog",
+                "Grants": "GRANT SELECT ON TABLE default_catalog.db.tbl TO USER 'alice'",
+            }
+        ]
+        conn = object()  # dummy
+        grants = _parse_show_grants(conn, "alice", "USER")
+        # Verify the SQL called
+        mock_exec.assert_called_once_with(conn, "SHOW GRANTS FOR 'alice'")
+        assert len(grants) == 1
+        g = grants[0]
+        assert g.privilege_type == "SELECT"
+        assert g.object_type == "TABLE"
+        assert g.object_catalog == "default_catalog"
+
+    @patch("app.services.common.grant_parser.execute_query")
+    def test_role_show_grants(self, mock_exec):
+        mock_exec.return_value = [
+            {
+                "Catalog": "default_catalog",
+                "Grants": "GRANT SELECT, INSERT ON TABLE default_catalog.db.tbl TO ROLE 'analyst'",
+            }
+        ]
+        conn = object()
+        grants = _parse_show_grants(conn, "analyst", "ROLE")
+        mock_exec.assert_called_once_with(conn, "SHOW GRANTS FOR ROLE 'analyst'")
+        assert len(grants) == 2
+
+    @patch("app.services.common.grant_parser.execute_query")
+    def test_user_with_at_sign(self, mock_exec):
+        mock_exec.return_value = []
+        conn = object()
+        _parse_show_grants(conn, "alice@192.168.1.1", "USER")
+        # Should use safe_name without quotes for @-containing users
+        call_sql = mock_exec.call_args[0][1]
+        assert "alice@192.168.1.1" in call_sql
+        assert "'" not in call_sql.split("FOR ")[1]  # no quotes around it
+
+    @patch("app.services.common.grant_parser.execute_query")
+    def test_catalog_context_fills_missing_catalog(self, mock_exec):
+        """When row has Catalog column but parsed grant has no catalog, fill it in."""
+        mock_exec.return_value = [
+            {
+                "Catalog": "hive_catalog",
+                "Grants": "GRANT SELECT ON TABLE db.tbl TO USER 'alice'",
+            }
+        ]
+        conn = object()
+        grants = _parse_show_grants(conn, "alice", "USER")
+        g = _single(grants)
+        # The 2-part "db.tbl" for TABLE → database=db, name=tbl, catalog=None
+        # Then row_catalog fills it in
+        assert g.object_catalog == "hive_catalog"
+        assert g.object_database == "db"
+        assert g.object_name == "tbl"
+
+    @patch("app.services.common.grant_parser.execute_query")
+    def test_catalog_context_not_applied_to_system_types(self, mock_exec):
+        """SYSTEM, STORAGE VOLUME, etc. should not get catalog filled."""
+        mock_exec.return_value = [
+            {
+                "Catalog": "default_catalog",
+                "Grants": "GRANT USAGE ON STORAGE VOLUME sv1 TO ROLE 'public'",
+            }
+        ]
+        conn = object()
+        grants = _parse_show_grants(conn, "public", "ROLE")
+        g = _single(grants)
+        assert g.object_type == "STORAGE VOLUME"
+        assert g.object_catalog is None  # should NOT be filled with default_catalog
+
+    @patch("app.services.common.grant_parser.execute_query")
+    def test_catalog_context_not_applied_to_global_function(self, mock_exec):
+        mock_exec.return_value = [
+            {
+                "Catalog": "default_catalog",
+                "Grants": "GRANT USAGE ON GLOBAL FUNCTION gfn(INT) TO ROLE 'r'",
+            }
+        ]
+        conn = object()
+        grants = _parse_show_grants(conn, "r", "ROLE")
+        g = _single(grants)
+        assert g.object_type == "GLOBAL FUNCTION"
+        assert g.object_catalog is None
+
+    @patch("app.services.common.grant_parser.execute_query")
+    def test_execute_query_exception_returns_empty(self, mock_exec):
+        mock_exec.side_effect = Exception("connection refused")
+        conn = object()
+        grants = _parse_show_grants(conn, "alice", "USER")
+        assert grants == []
+
+    @patch("app.services.common.grant_parser.execute_query")
+    def test_multiple_rows(self, mock_exec):
+        mock_exec.return_value = [
+            {
+                "Catalog": "default_catalog",
+                "Grants": "GRANT SELECT ON TABLE default_catalog.db.t1 TO USER 'alice'",
+            },
+            {
+                "Catalog": "default_catalog",
+                "Grants": "GRANT INSERT ON TABLE default_catalog.db.t2 TO USER 'alice'",
+            },
+        ]
+        conn = object()
+        grants = _parse_show_grants(conn, "alice", "USER")
+        assert len(grants) == 2
+        assert {g.object_name for g in grants} == {"t1", "t2"}
+
+    @patch("app.services.common.grant_parser.execute_query")
+    def test_non_grant_values_in_row_skipped(self, mock_exec):
+        """Values that don't start with GRANT should be ignored."""
+        mock_exec.return_value = [
+            {
+                "Catalog": "default_catalog",
+                "UserIdentity": "alice",
+                "Grants": "GRANT SELECT ON TABLE default_catalog.db.t1 TO USER 'alice'",
+            },
+        ]
+        conn = object()
+        grants = _parse_show_grants(conn, "alice", "USER")
+        assert len(grants) == 1
+
+    @patch("app.services.common.grant_parser.execute_query")
+    def test_lowercase_catalog_key(self, mock_exec):
+        """Row with lowercase 'catalog' key should still be recognized."""
+        mock_exec.return_value = [
+            {
+                "catalog": "hive_cat",
+                "Grants": "GRANT SELECT ON TABLE db.t TO USER 'alice'",
+            },
+        ]
+        conn = object()
+        grants = _parse_show_grants(conn, "alice", "USER")
+        g = _single(grants)
+        assert g.object_catalog == "hive_cat"

--- a/backend/tests/test_role_helpers.py
+++ b/backend/tests/test_role_helpers.py
@@ -1,0 +1,317 @@
+"""Unit tests for role_helpers.py and name_utils.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.utils.role_helpers import (
+    build_role_chain,
+    collect_all_roles_via_grants,
+    get_parent_roles,
+    get_user_roles,
+    parse_role_assignments,
+)
+from app.services.shared.name_utils import normalize_fn_name
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_conn():
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# 1. parse_role_assignments
+# ---------------------------------------------------------------------------
+
+class TestParseRoleAssignments:
+    @patch("app.utils.role_helpers.execute_query")
+    def test_single_role_grant(self, mock_eq):
+        mock_eq.return_value = [
+            {"GrantStatement": "GRANT 'analyst_role' TO USER 'alice'"},
+        ]
+        roles = parse_role_assignments(_mock_conn(), "alice", "USER")
+        assert roles == ["analyst_role"]
+
+    @patch("app.utils.role_helpers.execute_query")
+    def test_multiple_roles_comma_separated(self, mock_eq):
+        mock_eq.return_value = [
+            {"GrantStatement": "GRANT 'role1', 'role2' TO USER 'bob'"},
+        ]
+        roles = parse_role_assignments(_mock_conn(), "bob", "USER")
+        assert roles == ["role1", "role2"]
+
+    @patch("app.utils.role_helpers.execute_query")
+    def test_non_role_lines_ignored(self, mock_eq):
+        """Lines with ON (privilege grants) should be skipped."""
+        mock_eq.return_value = [
+            {"GrantStatement": "GRANT SELECT ON TABLE default_catalog.db.t TO USER 'alice'"},
+            {"GrantStatement": "GRANT 'analyst_role' TO USER 'alice'"},
+        ]
+        roles = parse_role_assignments(_mock_conn(), "alice", "USER")
+        assert roles == ["analyst_role"]
+
+    @patch("app.utils.role_helpers.execute_query")
+    def test_empty_results(self, mock_eq):
+        mock_eq.return_value = []
+        roles = parse_role_assignments(_mock_conn(), "alice", "USER")
+        assert roles == []
+
+    @patch("app.utils.role_helpers.execute_query")
+    def test_role_grantee_type(self, mock_eq):
+        """Should use SHOW GRANTS FOR ROLE syntax."""
+        mock_eq.return_value = [
+            {"GrantStatement": "GRANT 'parent_role' TO ROLE 'child_role'"},
+        ]
+        roles = parse_role_assignments(_mock_conn(), "child_role", "ROLE")
+        assert roles == ["parent_role"]
+        sql_called = mock_eq.call_args[0][1]
+        assert "FOR ROLE" in sql_called
+
+    @patch("app.utils.role_helpers.execute_query")
+    def test_user_grantee_type_sql(self, mock_eq):
+        mock_eq.return_value = []
+        parse_role_assignments(_mock_conn(), "alice", "USER")
+        sql_called = mock_eq.call_args[0][1]
+        assert "FOR ROLE" not in sql_called
+        assert "FOR 'alice'" in sql_called
+
+    @patch("app.utils.role_helpers.execute_query")
+    def test_duplicate_roles_deduplicated(self, mock_eq):
+        mock_eq.return_value = [
+            {"GrantStatement": "GRANT 'r1' TO USER 'u'"},
+            {"GrantStatement": "GRANT 'r1' TO USER 'u'"},
+        ]
+        roles = parse_role_assignments(_mock_conn(), "u", "USER")
+        assert roles == ["r1"]
+
+    @patch("app.utils.role_helpers.execute_query")
+    def test_execute_query_exception_returns_empty(self, mock_eq):
+        mock_eq.side_effect = Exception("connection lost")
+        roles = parse_role_assignments(_mock_conn(), "alice", "USER")
+        assert roles == []
+
+
+# ---------------------------------------------------------------------------
+# 2. build_role_chain
+# ---------------------------------------------------------------------------
+
+class TestBuildRoleChain:
+    @patch("app.utils.role_helpers.get_parent_roles")
+    @patch("app.utils.role_helpers.get_user_roles")
+    def test_simple_chain(self, mock_gur, mock_gpr):
+        mock_gur.return_value = ["role1"]
+        mock_gpr.side_effect = lambda conn, r: {"role1": ["role2"], "role2": []}.get(r, [])
+
+        result = build_role_chain(_mock_conn(), "alice", include_public=False)
+        assert "role1" in result
+        assert "role2" in result
+
+    @patch("app.utils.role_helpers.get_parent_roles")
+    @patch("app.utils.role_helpers.get_user_roles")
+    def test_include_public_true(self, mock_gur, mock_gpr):
+        mock_gur.return_value = ["role1"]
+        mock_gpr.return_value = []
+
+        result = build_role_chain(_mock_conn(), "alice", include_public=True)
+        assert "public" in result
+        assert "role1" in result
+
+    @patch("app.utils.role_helpers.get_parent_roles")
+    @patch("app.utils.role_helpers.get_user_roles")
+    def test_include_public_false(self, mock_gur, mock_gpr):
+        mock_gur.return_value = ["role1"]
+        mock_gpr.return_value = []
+
+        result = build_role_chain(_mock_conn(), "alice", include_public=False)
+        assert "public" not in result
+
+    @patch("app.utils.role_helpers.get_parent_roles")
+    @patch("app.utils.role_helpers.get_user_roles")
+    def test_public_not_duplicated_if_already_present(self, mock_gur, mock_gpr):
+        mock_gur.return_value = ["public", "role1"]
+        mock_gpr.return_value = []
+
+        result = build_role_chain(_mock_conn(), "alice", include_public=True)
+        assert list(result.keys()).count("public") == 1
+
+    @patch("app.utils.role_helpers.get_parent_roles")
+    @patch("app.utils.role_helpers.get_user_roles")
+    def test_cycle_detection(self, mock_gur, mock_gpr):
+        """role1 -> role2 -> role1 should terminate without infinite loop."""
+        mock_gur.return_value = ["role1"]
+        mock_gpr.side_effect = lambda conn, r: {
+            "role1": ["role2"],
+            "role2": ["role1"],
+        }.get(r, [])
+
+        result = build_role_chain(_mock_conn(), "alice", include_public=False)
+        assert "role1" in result
+        assert "role2" in result
+        # Should terminate (not hang)
+
+    @patch("app.utils.role_helpers.get_parent_roles")
+    @patch("app.utils.role_helpers.get_user_roles")
+    def test_depth_limit(self, mock_gur, mock_gpr):
+        """Chain deeper than 100 should be truncated."""
+        mock_gur.return_value = ["role_0"]
+        # Each role_N has parent role_{N+1}
+        mock_gpr.side_effect = lambda conn, r: (
+            [f"role_{int(r.split('_')[1]) + 1}"] if r.startswith("role_") else []
+        )
+
+        result = build_role_chain(_mock_conn(), "alice", include_public=False)
+        # BFS stops at 100 visited nodes
+        assert len(result) == 100
+
+    @patch("app.utils.role_helpers.get_parent_roles")
+    @patch("app.utils.role_helpers.get_user_roles")
+    def test_origin_tracking(self, mock_gur, mock_gpr):
+        """Origin should trace back to the direct role."""
+        mock_gur.return_value = ["role1"]
+        mock_gpr.side_effect = lambda conn, r: {"role1": ["role2"], "role2": ["role3"], "role3": []}.get(r, [])
+
+        result = build_role_chain(_mock_conn(), "alice", include_public=False)
+        assert result["role1"] == "role1"
+        assert result["role2"] == "role1"
+        assert result["role3"] == "role1"
+
+
+# ---------------------------------------------------------------------------
+# 3. get_user_roles
+# ---------------------------------------------------------------------------
+
+class TestGetUserRoles:
+    @patch("app.utils.role_helpers.execute_query")
+    def test_sys_role_edges_success(self, mock_eq):
+        mock_eq.return_value = [
+            {"FROM_ROLE": "analyst_role"},
+            {"FROM_ROLE": "etl_role"},
+        ]
+        roles = get_user_roles(_mock_conn(), "alice")
+        assert roles == ["analyst_role", "etl_role"]
+
+    @patch("app.utils.role_helpers.parse_role_assignments")
+    @patch("app.utils.role_helpers.execute_query")
+    def test_fallback_on_exception(self, mock_eq, mock_pra):
+        """When sys.role_edges fails, should fall back to parse_role_assignments."""
+        mock_eq.side_effect = Exception("access denied")
+        mock_pra.return_value = ["fallback_role"]
+
+        roles = get_user_roles(_mock_conn(), "alice")
+        assert roles == ["fallback_role"]
+        mock_pra.assert_called_once()
+
+    @patch("app.utils.role_helpers.parse_role_assignments")
+    @patch("app.utils.role_helpers.execute_query")
+    def test_fallback_on_empty_result(self, mock_eq, mock_pra):
+        """When sys.role_edges returns empty, should also fall back."""
+        mock_eq.return_value = []
+        mock_pra.return_value = ["grant_role"]
+
+        roles = get_user_roles(_mock_conn(), "alice")
+        assert roles == ["grant_role"]
+
+    @patch("app.utils.role_helpers.execute_query")
+    def test_alternative_key_role_name(self, mock_eq):
+        """Should handle ROLE_NAME key as fallback."""
+        mock_eq.return_value = [{"ROLE_NAME": "admin_role"}]
+        roles = get_user_roles(_mock_conn(), "alice")
+        assert roles == ["admin_role"]
+
+
+# ---------------------------------------------------------------------------
+# 4. get_parent_roles
+# ---------------------------------------------------------------------------
+
+class TestGetParentRoles:
+    @patch("app.utils.role_helpers.execute_query")
+    def test_sys_role_edges_success(self, mock_eq):
+        mock_eq.return_value = [{"FROM_ROLE": "root"}]
+        parents = get_parent_roles(_mock_conn(), "db_admin")
+        assert parents == ["root"]
+
+    @patch("app.utils.role_helpers.parse_role_assignments")
+    @patch("app.utils.role_helpers.execute_query")
+    def test_fallback_on_exception(self, mock_eq, mock_pra):
+        mock_eq.side_effect = Exception("access denied")
+        mock_pra.return_value = ["parent_via_grants"]
+
+        parents = get_parent_roles(_mock_conn(), "analyst_role")
+        assert parents == ["parent_via_grants"]
+        mock_pra.assert_called_once_with(mock_eq.call_args[0][0], "analyst_role", "ROLE")
+
+    @patch("app.utils.role_helpers.parse_role_assignments")
+    @patch("app.utils.role_helpers.execute_query")
+    def test_fallback_on_empty(self, mock_eq, mock_pra):
+        mock_eq.return_value = []
+        mock_pra.return_value = ["fallback_parent"]
+
+        parents = get_parent_roles(_mock_conn(), "some_role")
+        assert parents == ["fallback_parent"]
+
+    @patch("app.utils.role_helpers.execute_query")
+    def test_alternative_key_parent_role_name(self, mock_eq):
+        mock_eq.return_value = [{"PARENT_ROLE_NAME": "root"}]
+        parents = get_parent_roles(_mock_conn(), "db_admin")
+        assert parents == ["root"]
+
+    @patch("app.utils.role_helpers.execute_query")
+    def test_uses_to_role_param(self, mock_eq):
+        mock_eq.return_value = [{"FROM_ROLE": "root"}]
+        get_parent_roles(_mock_conn(), "my_role")
+        # First call should query sys.role_edges with TO_ROLE
+        first_sql = mock_eq.call_args_list[0][0][1]
+        assert "TO_ROLE" in first_sql
+
+
+# ---------------------------------------------------------------------------
+# 5. collect_all_roles_via_grants
+# ---------------------------------------------------------------------------
+
+class TestCollectAllRolesViaGrants:
+    @patch("app.utils.role_helpers.get_parent_roles")
+    @patch("app.utils.role_helpers.get_user_roles")
+    def test_returns_set_of_roles(self, mock_gur, mock_gpr):
+        mock_gur.return_value = ["role1", "role2"]
+        mock_gpr.return_value = []
+
+        result = collect_all_roles_via_grants(_mock_conn(), "alice")
+        assert isinstance(result, set)
+        assert "role1" in result
+        assert "role2" in result
+        assert "public" in result  # always included
+
+    @patch("app.utils.role_helpers.get_parent_roles")
+    @patch("app.utils.role_helpers.get_user_roles")
+    def test_includes_transitive_roles(self, mock_gur, mock_gpr):
+        mock_gur.return_value = ["role1"]
+        mock_gpr.side_effect = lambda conn, r: {"role1": ["role2"], "role2": []}.get(r, [])
+
+        result = collect_all_roles_via_grants(_mock_conn(), "alice")
+        assert result >= {"role1", "role2", "public"}
+
+
+# ---------------------------------------------------------------------------
+# 6. normalize_fn_name
+# ---------------------------------------------------------------------------
+
+class TestNormalizeFnName:
+    def test_strip_signature(self):
+        assert normalize_fn_name("my_func(INT, VARCHAR)") == "my_func"
+
+    def test_no_parentheses(self):
+        assert normalize_fn_name("simple_name") == "simple_name"
+
+    def test_empty_string(self):
+        assert normalize_fn_name("") == ""
+
+    def test_empty_parens(self):
+        assert normalize_fn_name("fn()") == "fn"
+
+    def test_nested_parens(self):
+        assert normalize_fn_name("fn(ARRAY(INT))") == "fn"


### PR DESCRIPTION
## Summary

Closes #12

핵심 서비스 모듈에 대한 단위 테스트 180개를 추가하여 테스트 커버리지를 대폭 강화합니다.

## New Test Files

| 파일 | 테스트 수 | 대상 모듈 |
|------|----------|----------|
| `test_grant_classifier.py` | 78 | `classify_grant()` 10+ 분기, `ObjectQuery`, 암묵적 USAGE 변환, 중복 제거 |
| `test_grant_parser.py` | 48 | GRANT SQL 정규식 파싱, `_row_to_grants` sys.* row 변환, `_parse_show_grants` |
| `test_bfs_resolver.py` | 23 | BFS 하향/상향 순회, 순환 감지, 다이아몬드 상속, `_finalize` |
| `test_role_helpers.py` | 31 | `build_role_chain`, `parse_role_assignments`, sys.role_edges fallback, `normalize_fn_name` |

**기존 66 → 총 246 tests** (+180)

## Test plan

- [x] `python -m pytest tests/ -v --ignore=tests/test_integration.py` — 246 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)