### PR TITLE
CI: integrate Codecov for unified coverage reporting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,6 +96,14 @@ jobs:
       - name: Run tests with coverage
         run: cd frontend && npm run test:coverage
 
+      - name: Upload frontend coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: frontend/coverage/lcov.info
+          flags: frontend
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   tests:
     name: Backend Tests
     runs-on: self-hosted
@@ -113,10 +121,18 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r backend/requirements.txt
-          pip install pytest
+          pip install pytest pytest-cov
 
-      - name: Run unit tests
-        run: cd backend && python -m pytest tests/ -v --ignore=tests/test_integration.py
+      - name: Run unit tests with coverage
+        run: cd backend && python -m pytest tests/ -v --ignore=tests/test_integration.py --cov=app --cov-report=xml:coverage.xml
+
+      - name: Upload backend coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: backend/coverage.xml
+          flags: backend
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   integration:
     name: Integration Tests (StarRocks)

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 **/venv
 *.pyc
 .pytest_cache/
+.coverage
+backend/coverage.xml
 frontend/node_modules/
 frontend/dist/
 frontend/coverage/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # StarRocks Permission Manager
 
+[![codecov](https://codecov.io/gh/EdwardArchive/starrocks-permission-manager/graph/badge.svg)](https://codecov.io/gh/EdwardArchive/starrocks-permission-manager)
+
 A web UI for visually exploring user, role, and object permission structures across StarRocks clusters using DAG (Directed Acyclic Graph) visualization.
 
 ![Login](docs/screenshots/login.png)
@@ -364,6 +366,72 @@ Uses `information_schema.tables` and `columns` as the primary data source, makin
 | v2.0 | GRANT/REVOKE UI, Bulk Operations |
 | v2.1 | Audit Log, Permission Diff |
 | v2.2 | Alert Rules, Export (CSV/PDF) |
+
+## Contributing
+
+### Prerequisites
+
+- Python 3.10+
+- Node.js 24+ (see `.nvmrc`)
+- A running StarRocks instance (for integration tests)
+
+### Development Setup
+
+```bash
+# Backend
+cd backend
+python -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+
+# Frontend
+cd frontend
+npm install
+```
+
+### Running Tests
+
+```bash
+# Backend unit tests (with coverage)
+cd backend
+python -m pytest tests/ -v --ignore=tests/test_integration.py --cov=app
+
+# Frontend unit tests (with coverage)
+cd frontend
+npm test              # run once
+npm run test:watch    # watch mode
+npm run test:coverage # with coverage report
+```
+
+### Code Quality
+
+All checks must pass before merging:
+
+```bash
+# Backend linting
+ruff check backend/app/
+ruff format backend/app/ --check
+
+# Frontend linting
+cd frontend
+npx tsc --noEmit
+npx eslint src/ --max-warnings 0
+```
+
+### Pull Request Guidelines
+
+1. Create a feature branch from `main` (`feature/your-feature` or `fix/your-fix`)
+2. Write tests for new functionality (backend: pytest, frontend: Vitest)
+3. Ensure all CI checks pass (lint, type check, tests)
+4. Coverage for new code should be 80%+ (enforced by Codecov patch check)
+5. Keep PRs focused — one feature or fix per PR
+
+### Project Conventions
+
+- **Backend**: Router files must NOT contain business logic (delegate to services)
+- **Backend**: No duplicate grant parsing — use `services/shared/grant_parser.py`
+- **Backend**: No hardcoded builtin roles — use `constants.BUILTIN_ROLES`
+- **Frontend**: Use `api/user.ts` for user-scoped endpoints, `api/admin.ts` for admin endpoints
+- **Frontend**: Test pure utility functions first, then stores, then components
 
 ## License
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,4 +8,5 @@ cachetools>=5.3.0,<6.0
 
 # dev / test
 pytest>=8.0.0,<9.0
+pytest-cov>=6.0.0,<7.0
 httpx>=0.27.0,<1.0

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+
+flags:
+  backend:
+    paths:
+      - backend/app/
+    carryforward: true
+  frontend:
+    paths:
+      - frontend/src/
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "backend/tests/**"
+  - "frontend/src/test/**"
+  - "frontend/src/main.tsx"


### PR DESCRIPTION
## Summary

- Integrate Codecov to track test coverage across both Python backend and Node.js frontend
- Add Contributing guide section to README

## Changes

| File | Change |
|------|--------|
| `backend/requirements.txt` | Add `pytest-cov` dependency |
| `.github/workflows/lint.yml` | Add `--cov` flags to pytest, add Codecov upload steps for both backend and frontend |
| `codecov.yml` | Codecov config: 80% patch target, backend/frontend flag separation, PR comment layout |
| `.gitignore` | Add `.coverage`, `backend/coverage.xml` |
| `README.md` | Add coverage badge, add Contributing section (setup, tests, PR guidelines, conventions) |

## How it works

1. **Backend Tests** job runs `pytest --cov=app --cov-report=xml` → uploads `coverage.xml`
2. **Frontend Tests** job runs `npm run test:coverage` → uploads `lcov.info`
3. Codecov **auto-merges** both reports into a single PR comment with per-flag breakdown
4. **Patch check**: new code must have 80%+ coverage or the status check warns

## Setup required after merge

- [ ] Enable repository at [codecov.io](https://codecov.io)
- [ ] Add `CODECOV_TOKEN` to repository secrets (Settings → Secrets → Actions)

## Test plan

- [x] No code logic changes — CI config and docs only
- [ ] Verify Codecov comment appears on next PR after token setup

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)