### PR TITLE
Test: improve coverage from 35% to ~68% (418 tests)

### DIFF
--- a/backend/tests/test_admin_dag_routes.py
+++ b/backend/tests/test_admin_dag_routes.py
@@ -1,0 +1,91 @@
+"""Tests for /api/admin/dag/* endpoints.
+
+Covers: admin_dag.py router — object hierarchy, role hierarchy, auth guard.
+"""
+from __future__ import annotations
+
+
+def test_admin_object_hierarchy(client, auth_header):
+    """GET /api/admin/dag/object-hierarchy returns a DAGGraph with SYSTEM node."""
+    resp = client.get(
+        "/api/admin/dag/object-hierarchy",
+        params={"catalog": "default_catalog"},
+        headers=auth_header,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "nodes" in data
+    assert "edges" in data
+    # SYSTEM node is always present
+    sys_nodes = [n for n in data["nodes"] if n["type"] == "system"]
+    assert len(sys_nodes) == 1
+    assert sys_nodes[0]["label"] == "SYSTEM"
+    # Should have catalog node
+    cat_nodes = [n for n in data["nodes"] if n["type"] == "catalog"]
+    assert any(n["label"] == "default_catalog" for n in cat_nodes)
+    # Should have database nodes
+    db_nodes = [n for n in data["nodes"] if n["type"] == "database"]
+    assert len(db_nodes) >= 1
+
+
+def test_admin_object_hierarchy_shallow(client, auth_header):
+    """depth=shallow returns catalogs+DBs but no individual objects."""
+    resp = client.get(
+        "/api/admin/dag/object-hierarchy",
+        params={"catalog": "default_catalog", "depth": "shallow"},
+        headers=auth_header,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    # Should have system, catalog, database nodes
+    node_types = {n["type"] for n in data["nodes"]}
+    assert "system" in node_types
+    assert "catalog" in node_types
+    assert "database" in node_types
+    # Should NOT have individual table/view nodes (no group nodes either)
+    table_nodes = [n for n in data["nodes"] if n["type"] == "table" and n.get("node_role") != "group"]
+    assert len(table_nodes) == 0
+
+
+def test_admin_role_hierarchy(client, auth_header):
+    """GET /api/admin/dag/role-hierarchy returns a DAGGraph with role+user nodes."""
+    resp = client.get("/api/admin/dag/role-hierarchy", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "nodes" in data
+    assert "edges" in data
+    node_types = {n["type"] for n in data["nodes"]}
+    assert "role" in node_types
+    # Should have user nodes (from sys.role_edges)
+    assert "user" in node_types
+    # Should have edges
+    assert len(data["edges"]) >= 1
+
+
+def test_admin_object_hierarchy_default_catalog(client, auth_header):
+    """Object hierarchy without catalog param defaults to default_catalog."""
+    resp = client.get("/api/admin/dag/object-hierarchy", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    cat_nodes = [n for n in data["nodes"] if n["type"] == "catalog"]
+    # Default param is "default_catalog" so only that catalog appears
+    assert len(cat_nodes) == 1
+    assert cat_nodes[0]["label"] == "default_catalog"
+
+
+def test_admin_object_hierarchy_has_edges(client, auth_header):
+    """Object hierarchy edges connect SYSTEM->catalog->database."""
+    resp = client.get(
+        "/api/admin/dag/object-hierarchy",
+        params={"catalog": "default_catalog"},
+        headers=auth_header,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    edge_sources = {e["source"] for e in data["edges"]}
+    edge_targets = {e["target"] for e in data["edges"]}
+    # SYSTEM should be a source
+    assert "sys" in edge_sources
+    # Catalog node should be a target of SYSTEM and source of DB edges
+    assert "c_default_catalog" in edge_targets
+    assert "c_default_catalog" in edge_sources

--- a/backend/tests/test_bfs_resolver.py
+++ b/backend/tests/test_bfs_resolver.py
@@ -1,0 +1,148 @@
+"""Unit tests for app.services.admin.bfs_resolver."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.models.schemas import PrivilegeGrant
+from app.services.admin.bfs_resolver import (
+    _bfs_child_roles,
+    _bfs_user_privs,
+    _finalize,
+    _find_ancestors_with_grants,
+)
+from app.services.common.grant_classifier import ObjectQuery, Relevance
+from tests.conftest import FakeConnection
+
+
+# ── _bfs_child_roles tests ──
+
+
+def test_bfs_child_roles_simple_chain():
+    """Simple chain: A->B->C, A has SELECT -> B and C get SELECT."""
+    role_privs = {"A": {"SELECT"}}
+    children_of = {"A": ["B"], "B": ["C"]}
+    result = _bfs_child_roles(role_privs, children_of)
+    assert "B" in result
+    assert "C" in result
+    assert "SELECT" in result["B"][0]
+    assert "SELECT" in result["C"][0]
+
+
+def test_bfs_child_roles_diamond():
+    """Diamond: A->B, A->C, B->D, C->D -> D gets all privs from A."""
+    role_privs = {"A": {"SELECT", "INSERT"}}
+    children_of = {"A": ["B", "C"], "B": ["D"], "C": ["D"]}
+    result = _bfs_child_roles(role_privs, children_of)
+    assert "D" in result
+    assert "SELECT" in result["D"][0]
+    assert "INSERT" in result["D"][0]
+
+
+def test_bfs_child_roles_empty_role_privs():
+    """Empty role_privs -> empty result."""
+    result = _bfs_child_roles({}, {"A": ["B"]})
+    assert result == {}
+
+
+def test_bfs_child_roles_cycle():
+    """Cycle: A->B->A -> terminates via visited set."""
+    role_privs = {"A": {"SELECT"}}
+    children_of = {"A": ["B"], "B": ["A"]}
+    result = _bfs_child_roles(role_privs, children_of)
+    # Should not hang; B inherits from A
+    assert "B" in result
+    assert "SELECT" in result["B"][0]
+
+
+# ── _bfs_user_privs tests ──
+
+
+@patch("app.services.admin.bfs_resolver.get_user_roles")
+def test_bfs_user_privs_fast_path(mock_user_roles):
+    """Fast path: user has role directly in role_privs -> returns immediately."""
+    mock_user_roles.return_value = ["role_a"]
+    conn = FakeConnection({})
+    role_privs = {"role_a": {"SELECT", "INSERT"}}
+    result = _bfs_user_privs(conn, "user1", role_privs)
+    assert "SELECT" in result
+    assert "INSERT" in result
+
+
+@patch("app.services.admin.bfs_resolver.get_parent_roles")
+@patch("app.services.admin.bfs_resolver.get_user_roles")
+def test_bfs_user_privs_slow_path(mock_user_roles, mock_parents):
+    """Slow path: user's direct role not in role_privs, but parent is -> BFS finds it."""
+    mock_user_roles.return_value = ["role_a"]
+    mock_parents.side_effect = lambda conn, role: {
+        "role_a": ["role_b"],
+        "role_b": [],
+    }.get(role, [])
+    conn = FakeConnection({})
+    role_privs = {"role_b": {"DELETE"}}
+    result = _bfs_user_privs(conn, "user1", role_privs)
+    assert "DELETE" in result
+
+
+@patch("app.services.admin.bfs_resolver.get_user_roles")
+def test_bfs_user_privs_no_roles(mock_user_roles):
+    """No roles -> returns empty dict."""
+    mock_user_roles.return_value = []
+    conn = FakeConnection({})
+    result = _bfs_user_privs(conn, "user1", {"role_a": {"SELECT"}})
+    assert result == {}
+
+
+# ── _finalize tests ──
+
+
+def test_finalize_implicit_usage_conversion():
+    """IMPLICIT_USAGE grants converted to USAGE, deduped per grantee."""
+    g1 = PrivilegeGrant(
+        grantee="role_a",
+        grantee_type="ROLE",
+        object_catalog=None,
+        object_database="db1",
+        object_name="tbl1",
+        object_type="TABLE",
+        privilege_type="SELECT",
+        is_grantable=False,
+        source="direct",
+    )
+    g2 = PrivilegeGrant(
+        grantee="role_a",
+        grantee_type="ROLE",
+        object_catalog=None,
+        object_database="db1",
+        object_name="tbl2",
+        object_type="TABLE",
+        privilege_type="INSERT",
+        is_grantable=False,
+        source="direct",
+    )
+    q = ObjectQuery(catalog=None, database="db1", name=None, object_type="DATABASE")
+
+    classified = [(g1, Relevance.IMPLICIT_USAGE), (g2, Relevance.IMPLICIT_USAGE)]
+    result = _finalize(classified, q)
+    # Both IMPLICIT_USAGE from same grantee -> one USAGE grant
+    assert len(result) == 1
+    assert result[0].privilege_type == "USAGE"
+    assert result[0].grantee == "role_a"
+    assert result[0].object_type == "DATABASE"
+
+
+# ── _find_ancestors_with_grants tests ──
+
+
+@patch("app.services.admin.bfs_resolver.get_parent_roles")
+def test_find_ancestors_grandparent(mock_parents):
+    """Grandparent has grants -> found via BFS upward."""
+    mock_parents.side_effect = lambda conn, role: {
+        "role_a": ["role_b"],
+        "role_b": ["role_c"],
+        "role_c": [],
+    }.get(role, [])
+    conn = FakeConnection({})
+    grants_map = {"role_c": [{"priv": "SELECT"}]}
+    result = _find_ancestors_with_grants(conn, "role_a", grants_map)
+    assert "role_c" in result

--- a/backend/tests/test_grant_classifier.py
+++ b/backend/tests/test_grant_classifier.py
@@ -1,0 +1,140 @@
+"""Unit tests for app.services.common.grant_classifier."""
+
+from __future__ import annotations
+
+from app.models.schemas import PrivilegeGrant
+from app.services.common.grant_classifier import (
+    ObjectQuery,
+    Relevance,
+    _deduplicate,
+    _scope_matches,
+    classify_grant,
+)
+
+
+# ── Helper ──
+
+
+def _grant(**kw) -> PrivilegeGrant:
+    defaults = dict(
+        grantee="u",
+        grantee_type="USER",
+        object_catalog=None,
+        object_database=None,
+        object_name=None,
+        object_type="TABLE",
+        privilege_type="SELECT",
+        is_grantable=False,
+        source="direct",
+    )
+    return PrivilegeGrant(**{**defaults, **kw})
+
+
+# ── classify_grant tests ──
+
+
+def test_system_query_system_grant_is_exact():
+    """SYSTEM query + SYSTEM grant -> EXACT."""
+    g = _grant(object_type="SYSTEM", privilege_type="OPERATE")
+    q = ObjectQuery(catalog=None, database=None, name=None, object_type="SYSTEM")
+    assert classify_grant(g, q) == Relevance.EXACT
+
+
+def test_system_query_table_grant_is_irrelevant():
+    """SYSTEM query + TABLE grant -> IRRELEVANT."""
+    g = _grant(object_type="TABLE", privilege_type="SELECT")
+    q = ObjectQuery(catalog=None, database=None, name=None, object_type="SYSTEM")
+    assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+
+def test_non_object_type_exact_name_match():
+    """Non-object type (STORAGE VOLUME) exact name match -> EXACT."""
+    g = _grant(object_type="STORAGE VOLUME", object_name="my_vol", privilege_type="USAGE")
+    q = ObjectQuery(catalog=None, database=None, name="my_vol", object_type="STORAGE VOLUME")
+    assert classify_grant(g, q) == Relevance.EXACT
+
+
+def test_non_object_type_wildcard_no_name_is_parent_scope():
+    """Non-object type wildcard (no name on grant) -> PARENT_SCOPE."""
+    g = _grant(object_type="STORAGE VOLUME", object_name=None, privilege_type="USAGE")
+    q = ObjectQuery(catalog=None, database=None, name="my_vol", object_type="STORAGE VOLUME")
+    assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+
+def test_scope_query_child_table_grant_is_implicit_usage():
+    """Scope query (DATABASE without name) + child TABLE grant in same db -> IMPLICIT_USAGE."""
+    g = _grant(
+        object_type="TABLE",
+        object_database="analytics_db",
+        object_name="tbl1",
+        privilege_type="SELECT",
+    )
+    q = ObjectQuery(catalog=None, database="analytics_db", name=None, object_type="DATABASE")
+    assert classify_grant(g, q) == Relevance.IMPLICIT_USAGE
+
+
+def test_named_table_query_db_create_table_is_parent_scope():
+    """Named TABLE query + DATABASE CREATE TABLE grant -> PARENT_SCOPE."""
+    g = _grant(
+        object_type="DATABASE",
+        object_database="analytics_db",
+        privilege_type="CREATE TABLE",
+    )
+    q = ObjectQuery(catalog=None, database="analytics_db", name="tbl1", object_type="TABLE")
+    assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+
+def test_named_table_query_db_create_view_is_irrelevant():
+    """Named TABLE query + DATABASE CREATE VIEW grant -> IRRELEVANT."""
+    g = _grant(
+        object_type="DATABASE",
+        object_database="analytics_db",
+        privilege_type="CREATE VIEW",
+    )
+    q = ObjectQuery(catalog=None, database="analytics_db", name="tbl1", object_type="TABLE")
+    assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+
+def test_wildcard_grant_mismatched_type_is_irrelevant():
+    """Wildcard grant (no coords) with mismatched type -> IRRELEVANT."""
+    g = _grant(object_type="VIEW", object_catalog=None, object_database=None, object_name=None)
+    q = ObjectQuery(catalog=None, database=None, name="tbl1", object_type="TABLE")
+    # VIEW wildcard does not cover TABLE
+    assert classify_grant(g, q) == Relevance.IRRELEVANT
+
+
+def test_system_create_resource_group_with_rg_query_is_parent_scope():
+    """SYSTEM CREATE RESOURCE GROUP priv + RESOURCE GROUP query -> PARENT_SCOPE."""
+    g = _grant(object_type="SYSTEM", privilege_type="CREATE RESOURCE GROUP")
+    q = ObjectQuery(catalog=None, database=None, name=None, object_type="RESOURCE GROUP")
+    assert classify_grant(g, q) == Relevance.PARENT_SCOPE
+
+
+# ── _scope_matches tests ──
+
+
+def test_scope_matches_catalog_mismatch():
+    """_scope_matches: catalog mismatch -> False."""
+    q = ObjectQuery(catalog="cat_a", database=None, name=None, object_type="TABLE")
+    assert _scope_matches("cat_b", None, None, q) is False
+
+
+def test_scope_matches_all_match():
+    """_scope_matches: all coordinates match -> True."""
+    q = ObjectQuery(catalog="cat_a", database="db1", name="tbl1", object_type="TABLE")
+    assert _scope_matches("cat_a", "db1", "tbl1", q) is True
+
+
+# ── _deduplicate tests ──
+
+
+def test_deduplicate_removes_duplicate_grants():
+    """_deduplicate: removes duplicate grants, keeps first occurrence."""
+    g1 = _grant(privilege_type="SELECT", source="direct")
+    g2 = _grant(privilege_type="SELECT", source="role_a")  # same key, different source
+    g3 = _grant(privilege_type="INSERT", source="direct")  # different priv
+    result = _deduplicate([g1, g2, g3])
+    assert len(result) == 2
+    assert result[0].privilege_type == "SELECT"
+    assert result[0].source == "direct"  # first occurrence kept
+    assert result[1].privilege_type == "INSERT"

--- a/backend/tests/test_grant_parser.py
+++ b/backend/tests/test_grant_parser.py
@@ -1,0 +1,248 @@
+"""Unit tests for app.services.common.grant_parser."""
+
+from __future__ import annotations
+
+from app.services.common.grant_parser import _parse_grant_statement, _parse_show_grants, _row_to_grants
+from tests.conftest import FakeConnection
+
+
+# ── _parse_grant_statement tests ──
+
+
+def test_simple_table_2part_path():
+    """Simple TABLE with 2-part path."""
+    grants = _parse_grant_statement(
+        "GRANT SELECT ON TABLE analytics_db.user_events TO 'admin'",
+        "admin",
+        "USER",
+    )
+    assert len(grants) == 1
+    g = grants[0]
+    assert g.object_type == "TABLE"
+    assert g.object_database == "analytics_db"
+    assert g.object_name == "user_events"
+    assert g.object_catalog is None
+    assert g.privilege_type == "SELECT"
+
+
+def test_3part_path():
+    """3-part path: catalog.database.name."""
+    grants = _parse_grant_statement(
+        "GRANT SELECT ON TABLE default_catalog.analytics_db.user_events TO 'admin'",
+        "admin",
+        "USER",
+    )
+    assert len(grants) == 1
+    g = grants[0]
+    assert g.object_catalog == "default_catalog"
+    assert g.object_database == "analytics_db"
+    assert g.object_name == "user_events"
+
+
+def test_all_tables_in_database():
+    """ALL TABLES IN DATABASE."""
+    grants = _parse_grant_statement(
+        "GRANT SELECT ON ALL TABLES IN DATABASE analytics_db TO 'admin'",
+        "admin",
+        "USER",
+    )
+    assert len(grants) == 1
+    g = grants[0]
+    assert g.object_type == "TABLE"
+    assert g.object_database == "analytics_db"
+    assert g.object_name is None
+
+
+def test_all_tables_in_all_databases():
+    """ALL TABLES IN ALL DATABASES."""
+    grants = _parse_grant_statement(
+        "GRANT SELECT ON ALL TABLES IN ALL DATABASES TO 'admin'",
+        "admin",
+        "USER",
+    )
+    assert len(grants) == 1
+    g = grants[0]
+    assert g.object_type == "TABLE"
+    assert g.object_database is None
+    assert g.object_name is None
+
+
+def test_storage_volume():
+    """Multi-word STORAGE VOLUME."""
+    grants = _parse_grant_statement(
+        "GRANT USAGE ON STORAGE VOLUME my_volume TO 'admin'",
+        "admin",
+        "USER",
+    )
+    assert len(grants) == 1
+    g = grants[0]
+    assert g.object_type == "STORAGE VOLUME"
+    assert g.object_name == "my_volume"
+
+
+def test_materialized_view():
+    """Multi-word MATERIALIZED VIEW."""
+    grants = _parse_grant_statement(
+        "GRANT SELECT ON MATERIALIZED VIEW analytics_db.hourly_agg TO 'admin'",
+        "admin",
+        "USER",
+    )
+    assert len(grants) == 1
+    g = grants[0]
+    assert g.object_type == "MATERIALIZED VIEW"
+    assert g.object_database == "analytics_db"
+    assert g.object_name == "hourly_agg"
+
+
+def test_database_1part_path():
+    """DATABASE 1-part path: X is database, not catalog."""
+    grants = _parse_grant_statement(
+        "GRANT CREATE TABLE ON DATABASE analytics_db TO 'admin'",
+        "admin",
+        "USER",
+    )
+    assert len(grants) == 1
+    g = grants[0]
+    assert g.object_type == "DATABASE"
+    assert g.object_database == "analytics_db"
+    assert g.object_catalog is None
+
+
+def test_multiple_privileges():
+    """Multiple privileges: comma-separated -> multiple PrivilegeGrant objects."""
+    grants = _parse_grant_statement(
+        "GRANT SELECT, INSERT, DELETE ON TABLE db.tbl TO 'admin'",
+        "admin",
+        "USER",
+    )
+    assert len(grants) == 3
+    privs = {g.privilege_type for g in grants}
+    assert privs == {"SELECT", "INSERT", "DELETE"}
+    for g in grants:
+        assert g.object_database == "db"
+        assert g.object_name == "tbl"
+
+
+def test_global_function_with_signature():
+    """GLOBAL FUNCTION with signature preserves full path."""
+    grants = _parse_grant_statement(
+        "GRANT USAGE ON GLOBAL FUNCTION gfn_mask(VARCHAR(65533)) TO 'admin'",
+        "admin",
+        "USER",
+    )
+    assert len(grants) == 1
+    g = grants[0]
+    assert g.object_type == "GLOBAL FUNCTION"
+    assert g.object_name == "gfn_mask(VARCHAR(65533))"
+
+
+def test_wildcard_path():
+    """Wildcard path *.*.* -> all None."""
+    grants = _parse_grant_statement(
+        "GRANT SELECT ON TABLE *.*.* TO 'admin'",
+        "admin",
+        "USER",
+    )
+    assert len(grants) == 1
+    g = grants[0]
+    assert g.object_catalog is None
+    assert g.object_database is None
+    assert g.object_name is None
+
+
+def test_no_match_revoke():
+    """No match (REVOKE) -> empty list."""
+    grants = _parse_grant_statement(
+        "REVOKE SELECT FROM role1",
+        "role1",
+        "ROLE",
+    )
+    assert grants == []
+
+
+def test_masking_policy():
+    """MASKING POLICY -> object_type='POLICY'."""
+    grants = _parse_grant_statement(
+        "GRANT USAGE ON MASKING POLICY db.my_policy TO 'admin'",
+        "admin",
+        "USER",
+    )
+    assert len(grants) == 1
+    g = grants[0]
+    assert g.object_type == "POLICY"
+
+
+# ── _row_to_grants tests ──
+
+
+def test_row_to_grants_basic():
+    """Basic row conversion with IS_GRANTABLE=YES."""
+    row = {
+        "GRANTEE": "user1",
+        "OBJECT_TYPE": "TABLE",
+        "OBJECT_CATALOG": "default_catalog",
+        "OBJECT_DATABASE": "db1",
+        "OBJECT_NAME": "tbl1",
+        "PRIVILEGE_TYPE": "SELECT",
+        "IS_GRANTABLE": "YES",
+    }
+    grants = _row_to_grants(row, "USER")
+    assert len(grants) == 1
+    g = grants[0]
+    assert g.grantee == "user1"
+    assert g.grantee_type == "USER"
+    assert g.is_grantable is True
+    assert g.privilege_type == "SELECT"
+    assert g.object_type == "TABLE"
+
+
+def test_row_to_grants_comma_split():
+    """Comma-separated PRIVILEGE_TYPE -> multiple grants."""
+    row = {
+        "GRANTEE": "user1",
+        "OBJECT_TYPE": "TABLE",
+        "OBJECT_CATALOG": None,
+        "OBJECT_DATABASE": "db1",
+        "OBJECT_NAME": "tbl1",
+        "PRIVILEGE_TYPE": "SELECT,INSERT",
+        "IS_GRANTABLE": "NO",
+    }
+    grants = _row_to_grants(row, "USER")
+    assert len(grants) == 2
+    privs = {g.privilege_type for g in grants}
+    assert privs == {"SELECT", "INSERT"}
+    assert all(g.is_grantable is False for g in grants)
+
+
+# ── _parse_show_grants tests ──
+
+
+def test_parse_show_grants_user_with_catalog_context():
+    """USER path with catalog context: row's Catalog column fills in catalog."""
+    query_map = {
+        "SHOW GRANTS FOR": [
+            {
+                "Catalog": "default_catalog",
+                "GrantPrivilege": "GRANT SELECT ON TABLE analytics_db.user_events TO 'testuser'",
+            },
+        ],
+    }
+    conn = FakeConnection(query_map)
+    grants = _parse_show_grants(conn, "testuser", "USER")
+    assert len(grants) == 1
+    g = grants[0]
+    assert g.object_catalog == "default_catalog"
+    assert g.object_database == "analytics_db"
+    assert g.object_name == "user_events"
+
+
+def test_parse_show_grants_exception_returns_empty():
+    """Exception handling: connection raises -> returns empty list."""
+
+    class BrokenConnection:
+        def cursor(self, dictionary=False):
+            raise RuntimeError("connection lost")
+
+    conn = BrokenConnection()
+    grants = _parse_show_grants(conn, "testuser", "USER")
+    assert grants == []

--- a/backend/tests/test_grant_resolver.py
+++ b/backend/tests/test_grant_resolver.py
@@ -1,0 +1,213 @@
+"""Unit tests for app.services.common.grant_resolver."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.models.schemas import PrivilegeGrant
+from app.services.common.grant_classifier import ObjectQuery
+from app.services.common.grant_resolver import GrantResolver
+from app.services.grant_collector import CollectedGrants
+from tests.conftest import FakeConnection
+
+
+# ── Helpers ──
+
+
+def _grant(**kw) -> PrivilegeGrant:
+    defaults = dict(
+        grantee="u",
+        grantee_type="USER",
+        object_catalog=None,
+        object_database=None,
+        object_name=None,
+        object_type="TABLE",
+        privilege_type="SELECT",
+        is_grantable=False,
+        source="direct",
+    )
+    return PrivilegeGrant(**{**defaults, **kw})
+
+
+def _collected(grants, role_chain=None, role_child_map=None, all_users=None):
+    return CollectedGrants(
+        grants=grants,
+        user_role_chain=role_chain or {},
+        role_child_map=role_child_map or {},
+        all_users=all_users or set(),
+    )
+
+
+# ── for_user tests ──
+
+
+def test_for_user_filters_by_username():
+    """for_user: filters by username."""
+    g1 = _grant(grantee="alice", privilege_type="SELECT")
+    g2 = _grant(grantee="bob", privilege_type="INSERT")
+    g3 = _grant(grantee="alice", privilege_type="DELETE")
+    c = _collected([g1, g2, g3])
+    resolver = GrantResolver(c)
+    result = resolver.for_user("alice")
+    assert len(result) == 2
+    assert all(g.grantee == "alice" for g in result)
+
+
+def test_for_user_empty_grants():
+    """for_user: empty grants -> empty result."""
+    c = _collected([])
+    resolver = GrantResolver(c)
+    result = resolver.for_user("alice")
+    assert result == []
+
+
+# ── for_user_effective tests ──
+
+
+def test_for_user_effective_direct_plus_role():
+    """for_user_effective: direct + role chain grants, source attributed."""
+    g_direct = _grant(grantee="alice", privilege_type="SELECT")
+    g_role = _grant(grantee="analyst_role", grantee_type="ROLE", privilege_type="INSERT")
+    c = _collected(
+        grants=[g_direct, g_role],
+        role_chain={"analyst_role": "analyst_role"},
+    )
+    resolver = GrantResolver(c)
+    result = resolver.for_user_effective("alice")
+    assert len(result) == 2
+    direct_grants = [g for g in result if g.grantee == "alice"]
+    role_grants = [g for g in result if g.grantee == "analyst_role"]
+    assert len(direct_grants) == 1
+    assert direct_grants[0].source == "direct"
+    assert len(role_grants) == 1
+    assert role_grants[0].source == "analyst_role"
+
+
+def test_for_user_effective_no_roles():
+    """for_user_effective: no roles -> only direct grants."""
+    g_direct = _grant(grantee="alice", privilege_type="SELECT")
+    g_other = _grant(grantee="role_a", grantee_type="ROLE", privilege_type="INSERT")
+    c = _collected(grants=[g_direct, g_other], role_chain={})
+    resolver = GrantResolver(c)
+    result = resolver.for_user_effective("alice")
+    assert len(result) == 1
+    assert result[0].grantee == "alice"
+
+
+# ── for_role tests ──
+
+
+def test_for_role_direct_grants_no_conn():
+    """for_role: direct grants only (no conn)."""
+    g1 = _grant(grantee="analyst_role", grantee_type="ROLE", privilege_type="SELECT")
+    g2 = _grant(grantee="other_role", grantee_type="ROLE", privilege_type="INSERT")
+    c = _collected([g1, g2])
+    resolver = GrantResolver(c, conn=None)
+    result = resolver.for_role("analyst_role")
+    assert len(result) == 1
+    assert result[0].grantee == "analyst_role"
+    assert result[0].source == "direct"
+
+
+@patch("app.services.common.grant_resolver.get_parent_roles")
+def test_for_role_with_parents(mock_parents):
+    """for_role: with conn + parent roles via BFS."""
+    mock_parents.side_effect = lambda conn, role: {
+        "analyst_role": ["parent_role"],
+        "parent_role": [],
+    }.get(role, [])
+
+    g_child = _grant(grantee="analyst_role", grantee_type="ROLE", privilege_type="SELECT")
+    g_parent = _grant(grantee="parent_role", grantee_type="ROLE", privilege_type="INSERT")
+    c = _collected([g_child, g_parent])
+    conn = FakeConnection({})
+    resolver = GrantResolver(c, conn=conn)
+    result = resolver.for_role("analyst_role")
+    assert len(result) == 2
+    grantees = {g.grantee for g in result}
+    assert grantees == {"analyst_role", "parent_role"}
+
+
+# ── for_object tests ──
+
+
+def test_for_object_exact_match():
+    """for_object: basic classification (EXACT match)."""
+    g = _grant(
+        grantee="role_a",
+        grantee_type="ROLE",
+        object_database="db1",
+        object_name="tbl1",
+        object_type="TABLE",
+        privilege_type="SELECT",
+    )
+    c = _collected([g])
+    resolver = GrantResolver(c)
+    q = ObjectQuery(catalog=None, database="db1", name="tbl1", object_type="TABLE")
+    result = resolver.for_object(q)
+    assert len(result) == 1
+    assert result[0].privilege_type == "SELECT"
+
+
+def test_for_object_bfs_child_roles():
+    """for_object: BFS child roles (role_child_map populated)."""
+    g = _grant(
+        grantee="parent_role",
+        grantee_type="ROLE",
+        object_database="db1",
+        object_name="tbl1",
+        object_type="TABLE",
+        privilege_type="SELECT",
+    )
+    c = _collected(
+        grants=[g],
+        role_child_map={"parent_role": ["child_role"]},
+    )
+    resolver = GrantResolver(c)
+    q = ObjectQuery(catalog=None, database="db1", name="tbl1", object_type="TABLE")
+    result = resolver.for_object(q)
+    # parent_role's grant + child_role inherits via BFS
+    grantees = {g.grantee for g in result}
+    assert "parent_role" in grantees
+    assert "child_role" in grantees
+
+
+def test_for_object_non_admin_path():
+    """for_object: non-admin path - user_role_chain set, all_users empty."""
+    g_role = _grant(
+        grantee="analyst_role",
+        grantee_type="ROLE",
+        object_database="db1",
+        object_name="tbl1",
+        object_type="TABLE",
+        privilege_type="SELECT",
+    )
+    g_user = _grant(
+        grantee="alice",
+        grantee_type="USER",
+        object_database="db1",
+        object_name="tbl1",
+        object_type="TABLE",
+        privilege_type="INSERT",
+    )
+    c = _collected(
+        grants=[g_role, g_user],
+        role_chain={"analyst_role": "analyst_role"},
+        all_users=set(),  # non-admin: empty
+    )
+    resolver = GrantResolver(c, conn=None)
+    q = ObjectQuery(catalog=None, database="db1", name="tbl1", object_type="TABLE")
+    result = resolver.for_object(q)
+    # Both role and user grants should be present; user inherits from role chain
+    grantees = {g.grantee for g in result}
+    assert "analyst_role" in grantees
+    assert "alice" in grantees
+
+
+def test_for_object_empty_grants():
+    """for_object: empty grants -> empty result."""
+    c = _collected([])
+    resolver = GrantResolver(c)
+    q = ObjectQuery(catalog=None, database="db1", name="tbl1", object_type="TABLE")
+    result = resolver.for_object(q)
+    assert result == []

--- a/backend/tests/test_show_grants_collector.py
+++ b/backend/tests/test_show_grants_collector.py
@@ -1,0 +1,145 @@
+"""Unit tests for app.services.common.show_grants_collector."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.models.schemas import PrivilegeGrant
+from app.services.common.show_grants_collector import _probe_public_defaults, collect_non_admin
+from tests.conftest import FakeConnection
+
+
+def _grant(**kw) -> PrivilegeGrant:
+    defaults = dict(
+        grantee="u",
+        grantee_type="USER",
+        object_catalog=None,
+        object_database=None,
+        object_name=None,
+        object_type="TABLE",
+        privilege_type="SELECT",
+        is_grantable=False,
+        source="direct",
+    )
+    return PrivilegeGrant(**{**defaults, **kw})
+
+
+# ── collect_non_admin tests ──
+
+
+@patch("app.services.common.show_grants_collector.fetch_role_child_map")
+@patch("app.services.common.show_grants_collector.build_role_chain")
+@patch("app.services.common.show_grants_collector._parse_show_grants")
+def test_collect_non_admin_happy_path(mock_parse, mock_chain, mock_child_map):
+    """Happy path: collect_non_admin returns grants from user + roles."""
+    user_grant = _grant(grantee="testuser", privilege_type="SELECT")
+    role_grant = _grant(grantee="role_a", grantee_type="ROLE", privilege_type="INSERT")
+
+    mock_parse.side_effect = [
+        [user_grant],  # user grants
+        [role_grant],  # role_a grants
+    ]
+    mock_chain.return_value = {"role_a": "role_a"}
+    mock_child_map.return_value = {}
+
+    conn = FakeConnection({})
+    result = collect_non_admin(conn, "testuser")
+
+    assert len(result.grants) == 2
+    assert result.user_role_chain == {"role_a": "role_a"}
+    assert result.all_users == set()
+    assert result.role_child_map == {}
+
+
+@patch("app.services.common.show_grants_collector._probe_public_defaults")
+@patch("app.services.common.show_grants_collector.fetch_role_child_map")
+@patch("app.services.common.show_grants_collector.build_role_chain")
+@patch("app.services.common.show_grants_collector._parse_show_grants")
+def test_collect_non_admin_public_empty_triggers_probe(mock_parse, mock_chain, mock_child_map, mock_probe):
+    """Public empty triggers probe: public role returning empty grants -> _probe_public_defaults called."""
+    user_grant = _grant(grantee="testuser", privilege_type="SELECT")
+    probe_grant = _grant(
+        grantee="public",
+        grantee_type="ROLE",
+        object_type="STORAGE VOLUME",
+        object_name="sv1",
+        privilege_type="USAGE",
+    )
+
+    mock_parse.side_effect = [
+        [user_grant],  # user grants
+        [],  # public role grants (empty -> triggers probe)
+    ]
+    mock_chain.return_value = {"public": "public"}
+    mock_child_map.return_value = {}
+    mock_probe.return_value = [probe_grant]
+
+    conn = FakeConnection({})
+    result = collect_non_admin(conn, "testuser")
+
+    mock_probe.assert_called_once_with(conn)
+    assert any(g.object_type == "STORAGE VOLUME" for g in result.grants)
+
+
+# ── _probe_public_defaults tests ──
+
+
+@patch("app.services.common.show_grants_collector.execute_query")
+def test_probe_public_defaults_storage_volume(mock_exec):
+    """SHOW STORAGE VOLUMES + DESC -> USAGE grant."""
+    mock_exec.side_effect = [
+        [{"Name": "sv1"}],  # SHOW STORAGE VOLUMES
+        [{}],  # DESC STORAGE VOLUME sv1 (succeeds)
+        [],  # SHOW WAREHOUSES
+    ]
+    conn = FakeConnection({})
+    result = _probe_public_defaults(conn)
+    sv_grants = [g for g in result if g.object_type == "STORAGE VOLUME"]
+    assert len(sv_grants) == 1
+    assert sv_grants[0].object_name == "sv1"
+    assert sv_grants[0].privilege_type == "USAGE"
+
+
+@patch("app.services.common.show_grants_collector.execute_query")
+def test_probe_public_defaults_warehouses(mock_exec):
+    """SHOW WAREHOUSES -> USAGE grant."""
+    mock_exec.side_effect = [
+        [],  # SHOW STORAGE VOLUMES (empty)
+        [{"Name": "wh1"}],  # SHOW WAREHOUSES
+    ]
+    conn = FakeConnection({})
+    result = _probe_public_defaults(conn)
+    wh_grants = [g for g in result if g.object_type == "WAREHOUSE"]
+    assert len(wh_grants) == 1
+    assert wh_grants[0].object_name == "wh1"
+    assert wh_grants[0].privilege_type == "USAGE"
+
+
+@patch("app.services.common.show_grants_collector.execute_query")
+def test_probe_public_defaults_desc_fails(mock_exec):
+    """DESC raises exception -> no STORAGE VOLUME grant but continues to warehouses."""
+    mock_exec.side_effect = [
+        [{"Name": "sv1"}],  # SHOW STORAGE VOLUMES
+        Exception("DESC failed"),  # DESC STORAGE VOLUME raises
+        [{"Name": "wh1"}],  # SHOW WAREHOUSES
+    ]
+    conn = FakeConnection({})
+    result = _probe_public_defaults(conn)
+    # No storage volume grant (DESC failed)
+    sv_grants = [g for g in result if g.object_type == "STORAGE VOLUME"]
+    assert len(sv_grants) == 0
+    # Warehouse still works
+    wh_grants = [g for g in result if g.object_type == "WAREHOUSE"]
+    assert len(wh_grants) == 1
+
+
+@patch("app.services.common.show_grants_collector.execute_query")
+def test_probe_public_defaults_both_commands_fail(mock_exec):
+    """Both SHOW commands raise -> returns empty."""
+    mock_exec.side_effect = [
+        Exception("SHOW STORAGE VOLUMES failed"),
+        Exception("SHOW WAREHOUSES failed"),
+    ]
+    conn = FakeConnection({})
+    result = _probe_public_defaults(conn)
+    assert result == []

--- a/backend/tests/test_starrocks_client.py
+++ b/backend/tests/test_starrocks_client.py
@@ -1,0 +1,90 @@
+"""Tests for app/services/starrocks_client.py.
+
+Covers: execute_query, execute_single, get_connection, test_connection.
+Uses FakeConnection from conftest for query tests and unittest.mock for connection tests.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from tests.conftest import FakeConnection
+import app.services.starrocks_client as sc_module
+
+execute_query = sc_module.execute_query
+execute_single = sc_module.execute_single
+get_connection = sc_module.get_connection
+_test_connection = sc_module.test_connection
+
+
+def test_execute_query_basic():
+    """execute_query returns list of dicts from FakeConnection."""
+    qmap = {"SELECT 1": [{"val": 1}]}
+    conn = FakeConnection(qmap)
+    result = execute_query(conn, "SELECT 1")
+    assert result == [{"val": 1}]
+
+
+def test_execute_query_empty():
+    """execute_query returns empty list when no rows match."""
+    conn = FakeConnection({})
+    result = execute_query(conn, "SELECT * FROM nonexistent")
+    assert result == []
+
+
+def test_execute_query_with_params():
+    """Params are passed through to cursor.execute (FakeCursor ignores them but no error)."""
+    qmap = {"SELECT * FROM t WHERE id": [{"id": 42}]}
+    conn = FakeConnection(qmap)
+    result = execute_query(conn, "SELECT * FROM t WHERE id = %s", (42,))
+    assert result == [{"id": 42}]
+
+
+def test_execute_single_returns_first():
+    """execute_single returns the first row when multiple rows exist."""
+    qmap = {"SELECT": [{"a": 1}, {"a": 2}, {"a": 3}]}
+    conn = FakeConnection(qmap)
+    result = execute_single(conn, "SELECT * FROM t")
+    assert result == {"a": 1}
+
+
+def test_execute_single_empty():
+    """execute_single returns None when no rows match."""
+    conn = FakeConnection({})
+    result = execute_single(conn, "SELECT * FROM nonexistent")
+    assert result is None
+
+
+@patch("app.services.starrocks_client.mysql.connector.connect")
+def test_test_connection_success(mock_connect):
+    """test_connection returns True when connect succeeds."""
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = [{"1": 1}]
+    mock_conn.cursor.return_value = mock_cursor
+    mock_connect.return_value = mock_conn
+    # get_connection is a context manager, need to handle __enter__/__exit__
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+
+    result = _test_connection("host", 9030, "user", "pass")
+    assert result is True
+    mock_connect.assert_called_once()
+
+
+@patch("app.services.starrocks_client.mysql.connector.connect")
+def test_check_connection_failure(mock_connect):
+    """test_connection returns False when connect raises."""
+    mock_connect.side_effect = Exception("Connection refused")
+    result = _test_connection("host", 9030, "user", "pass")
+    assert result is False
+
+
+@patch("app.services.starrocks_client.mysql.connector.connect")
+def test_get_connection_context_manager(mock_connect):
+    """get_connection yields a connection and closes it on exit."""
+    mock_conn = MagicMock()
+    mock_connect.return_value = mock_conn
+
+    with get_connection("host", 9030, "user", "pass") as conn:
+        assert conn is mock_conn
+    mock_conn.close.assert_called_once()

--- a/backend/tests/test_user_permissions.py
+++ b/backend/tests/test_user_permissions.py
@@ -1,0 +1,183 @@
+"""Tests for GET /api/user/my-permissions endpoint.
+
+Covers: user_permissions.py router — direct grants, role BFS, catalogs,
+databases, objects, functions, MVs, system objects, effective privileges.
+"""
+from __future__ import annotations
+
+
+def test_my_permissions_basic(client, auth_header):
+    """Default query_map returns the expected top-level keys."""
+    resp = client.get("/api/user/my-permissions", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["username"] == "test_admin"
+    for key in ("direct_roles", "role_tree", "effective_privileges",
+                "accessible_catalogs", "accessible_databases",
+                "accessible_objects", "system_objects"):
+        assert key in data, f"Missing key: {key}"
+
+
+def test_my_permissions_with_roles(client, auth_header, query_map):
+    """SHOW GRANTS returning role assignment populates direct_roles and role_tree."""
+    query_map["SHOW GRANTS FOR"] = [
+        # Role assignment row (no ON clause)
+        {"Grants": "GRANT 'analyst_role' TO 'test_admin'@'%'"},
+        # Privilege grant row
+        {
+            "Grants": "GRANT SELECT ON TABLE default_catalog.analytics_db.user_events TO 'test_admin'@'%'",
+            "Catalog": "default_catalog",
+        },
+    ]
+    # Role's own grants
+    query_map["SHOW GRANTS FOR ROLE 'analyst_role'"] = [
+        {
+            "Grants": "GRANT INSERT ON TABLE default_catalog.analytics_db.page_views TO ROLE 'analyst_role'",
+            "Catalog": "default_catalog",
+        },
+    ]
+    resp = client.get("/api/user/my-permissions", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "analyst_role" in data["direct_roles"]
+    assert "analyst_role" in data["role_tree"]
+
+
+def test_my_permissions_effective_privileges(client, auth_header, query_map):
+    """Effective privileges include both direct and role-inherited grants."""
+    query_map["SHOW GRANTS FOR 'test_admin'"] = [
+        {"Grants": "GRANT 'analyst_role' TO 'test_admin'@'%'"},
+        {
+            "Grants": "GRANT SELECT ON TABLE default_catalog.analytics_db.user_events TO 'test_admin'@'%'",
+            "Catalog": "default_catalog",
+        },
+    ]
+    query_map["SHOW GRANTS FOR ROLE 'analyst_role'"] = [
+        {
+            "Grants": "GRANT INSERT ON TABLE default_catalog.analytics_db.page_views TO ROLE 'analyst_role'",
+            "Catalog": "default_catalog",
+        },
+    ]
+    resp = client.get("/api/user/my-permissions", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    priv_types = {p["privilege_type"] for p in data["effective_privileges"]}
+    assert "SELECT" in priv_types
+    assert "INSERT" in priv_types
+    # Direct grant source should be "direct"
+    direct = [p for p in data["effective_privileges"] if p["source"] == "direct"]
+    assert any(p["privilege_type"] == "SELECT" for p in direct)
+
+
+def test_my_permissions_system_objects(client, auth_header, query_map):
+    """System objects (resource groups, warehouses, etc.) appear in response."""
+    query_map["SHOW RESOURCE GROUPS ALL"] = [
+        {"name": "rg_etl", "cpu_weight": "8", "mem_limit": "50%", "concurrency_limit": "10"},
+    ]
+    query_map["SHOW STORAGE VOLUMES"] = [
+        {"Storage Volume": "sv_main"},
+    ]
+    query_map["DESC STORAGE VOLUME"] = [
+        {"Type": "S3", "Location": "s3://bucket", "IsDefault": "true", "Enabled": "true"},
+    ]
+    query_map["SHOW WAREHOUSES"] = [
+        {"Name": "default_warehouse", "State": "RUNNING", "NodeCount": "3",
+         "RunningSql": "5", "QueuedSql": "0"},
+    ]
+    query_map["SHOW FULL GLOBAL FUNCTIONS"] = [
+        {"Signature": "gfn_mask(VARCHAR)", "Return Type": "VARCHAR", "Function Type": "Scalar"},
+    ]
+    query_map["SELECT * FROM information_schema.pipes"] = [
+        {"PIPE_NAME": "pipe_load", "DATABASE_NAME": "analytics_db",
+         "STATE": "RUNNING", "TABLE_NAME": "events", "LOAD_STATUS": "OK"},
+    ]
+    query_map["SELECT * FROM information_schema.tasks"] = [
+        {"TASK_NAME": "etl_daily", "DATABASE": "analytics_db",
+         "SCHEDULE": "EVERY 1 HOUR", "STATE": "", "CREATOR": "admin", "DEFINITION": "INSERT INTO ..."},
+    ]
+    query_map["SELECT TASK_NAME, STATE FROM information_schema.task_runs"] = [
+        {"TASK_NAME": "etl_daily", "STATE": "SUCCESS"},
+    ]
+    query_map["SHOW RESOURCES"] = [
+        {"Name": "jdbc_pg", "ResourceType": "jdbc", "Key": "jdbc_uri", "Value": "jdbc:postgresql://host/db"},
+    ]
+    resp = client.get("/api/user/my-permissions", headers=auth_header)
+    assert resp.status_code == 200
+    sys_objs = resp.json()["system_objects"]
+    types_found = {o["type"] for o in sys_objs}
+    assert "RESOURCE_GROUP" in types_found
+    assert "STORAGE_VOLUME" in types_found
+    assert "WAREHOUSE" in types_found
+    assert "GLOBAL_FUNCTION" in types_found
+    assert "PIPE" in types_found
+    assert "TASK" in types_found
+    assert "RESOURCE" in types_found
+    # Verify details propagated
+    rg = next(o for o in sys_objs if o["type"] == "RESOURCE_GROUP")
+    assert rg["name"] == "rg_etl"
+
+
+def test_my_permissions_functions(client, auth_header, query_map):
+    """Functions returned by SHOW FULL FUNCTIONS appear in accessible_objects."""
+    query_map["SHOW FULL FUNCTIONS FROM"] = [
+        {"Signature": "parse_ua(VARCHAR)", "Return Type": "VARCHAR",
+         "Function Type": "Scalar", "Properties": ""},
+    ]
+    resp = client.get("/api/user/my-permissions", headers=auth_header)
+    assert resp.status_code == 200
+    objs = resp.json()["accessible_objects"]
+    fns = [o for o in objs if o["type"] == "FUNCTION"]
+    assert len(fns) >= 1
+    assert fns[0]["name"] == "parse_ua"
+    assert fns[0]["signature"] == "parse_ua(VARCHAR)"
+
+
+def test_my_permissions_mv_detection(client, auth_header, query_map):
+    """Objects found in materialized_views are typed as MATERIALIZED VIEW."""
+    query_map["SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, DATA_LENGTH"] = [
+        {"TABLE_SCHEMA": "analytics_db", "TABLE_NAME": "hourly_agg_mv",
+         "TABLE_TYPE": "BASE TABLE", "TABLE_ROWS": 100, "DATA_LENGTH": 5000},
+        {"TABLE_SCHEMA": "analytics_db", "TABLE_NAME": "user_events",
+         "TABLE_TYPE": "BASE TABLE", "TABLE_ROWS": 1000, "DATA_LENGTH": 50000},
+    ]
+    query_map["SELECT TABLE_SCHEMA, TABLE_NAME FROM information_schema.materialized_views"] = [
+        {"TABLE_SCHEMA": "analytics_db", "TABLE_NAME": "hourly_agg_mv"},
+    ]
+    resp = client.get("/api/user/my-permissions", headers=auth_header)
+    assert resp.status_code == 200
+    objs = resp.json()["accessible_objects"]
+    mvs = [o for o in objs if o["type"] == "MATERIALIZED VIEW"]
+    assert any(mv["name"] == "hourly_agg_mv" for mv in mvs)
+    # The regular table should not be a MV
+    tables = [o for o in objs if o["name"] == "user_events"]
+    assert all(t["type"] != "MATERIALIZED VIEW" for t in tables)
+
+
+def test_my_permissions_catalogs_and_databases(client, auth_header):
+    """Catalogs have type, databases have catalog field."""
+    resp = client.get("/api/user/my-permissions", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    catalogs = data["accessible_catalogs"]
+    assert len(catalogs) >= 1
+    for cat in catalogs:
+        assert "name" in cat
+        assert "type" in cat
+    databases = data["accessible_databases"]
+    for db in databases:
+        assert "name" in db
+        assert "catalog" in db
+
+
+def test_my_permissions_view_detection(client, auth_header, query_map):
+    """Objects with VIEW in TABLE_TYPE are typed as VIEW."""
+    query_map["SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, DATA_LENGTH"] = [
+        {"TABLE_SCHEMA": "analytics_db", "TABLE_NAME": "daily_summary",
+         "TABLE_TYPE": "VIEW", "TABLE_ROWS": None, "DATA_LENGTH": None},
+    ]
+    query_map["SELECT TABLE_SCHEMA, TABLE_NAME FROM information_schema.materialized_views"] = []
+    resp = client.get("/api/user/my-permissions", headers=auth_header)
+    assert resp.status_code == 200
+    objs = resp.json()["accessible_objects"]
+    views = [o for o in objs if o["type"] == "VIEW"]
+    assert any(v["name"] == "daily_summary" for v in views)

--- a/backend/tests/test_user_roles_routes.py
+++ b/backend/tests/test_user_roles_routes.py
@@ -1,0 +1,106 @@
+"""Tests for /api/user/roles/* endpoints.
+
+Covers: user_roles.py router — list roles, hierarchy DAG, inheritance DAG.
+"""
+from __future__ import annotations
+
+
+def test_user_list_roles(client, auth_header, query_map):
+    """GET /api/user/roles returns a list of role items."""
+    # get_user_roles tries sys.role_edges first → override to include analyst_role
+    query_map["SELECT FROM_ROLE FROM sys.role_edges WHERE TO_USER"] = [
+        {"FROM_ROLE": "analyst_role"},
+        {"FROM_ROLE": "public"},
+    ]
+    # get_parent_roles for analyst_role → no parents
+    query_map["SELECT FROM_ROLE FROM sys.role_edges WHERE TO_ROLE"] = []
+    resp = client.get("/api/user/roles", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    names = {r["name"] for r in data}
+    assert "analyst_role" in names
+    assert "public" in names
+
+
+def test_user_list_roles_returns_builtin_flag(client, auth_header, query_map):
+    """Builtin roles have is_builtin=True."""
+    query_map["SELECT FROM_ROLE FROM sys.role_edges WHERE TO_USER"] = [
+        {"FROM_ROLE": "public"},
+    ]
+    query_map["SELECT FROM_ROLE FROM sys.role_edges WHERE TO_ROLE"] = []
+    resp = client.get("/api/user/roles", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    public_role = next((r for r in data if r["name"] == "public"), None)
+    assert public_role is not None
+    assert public_role["is_builtin"] is True
+
+
+def test_user_role_hierarchy(client, auth_header, query_map):
+    """GET /api/user/roles/hierarchy returns a DAGGraph with nodes and edges."""
+    # parse_role_assignments for USER calls SHOW GRANTS FOR 'test_admin'
+    query_map["SHOW GRANTS FOR 'test_admin'"] = [
+        {"Grants": "GRANT 'analyst_role' TO 'test_admin'@'%'"},
+    ]
+    # parse_role_assignments for ROLE calls SHOW GRANTS FOR ROLE 'analyst_role'
+    query_map["SHOW GRANTS FOR ROLE 'analyst_role'"] = []
+    query_map["SHOW GRANTS FOR ROLE"] = []
+    resp = client.get("/api/user/roles/hierarchy", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "nodes" in data
+    assert "edges" in data
+    # Should have user node + role nodes
+    node_types = {n["type"] for n in data["nodes"]}
+    assert "user" in node_types
+    assert "role" in node_types
+
+
+def test_user_inheritance_dag_user(client, auth_header, query_map):
+    """GET /api/user/roles/inheritance-dag?name=test_admin&type=user returns DAG with user node."""
+    # get_user_roles tries sys.role_edges first, which exists in DEFAULT_QUERY_MAP
+    resp = client.get(
+        "/api/user/roles/inheritance-dag",
+        params={"name": "test_admin", "type": "user"},
+        headers=auth_header,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "nodes" in data
+    assert "edges" in data
+    # User node must be present and highlighted
+    user_nodes = [n for n in data["nodes"] if n["type"] == "user"]
+    assert len(user_nodes) >= 1
+    assert user_nodes[0]["label"] == "test_admin"
+    assert user_nodes[0]["metadata"]["highlight"] is True
+
+
+def test_user_inheritance_dag_role(client, auth_header):
+    """GET /api/user/roles/inheritance-dag?name=analyst_role&type=role returns DAG with role node."""
+    resp = client.get(
+        "/api/user/roles/inheritance-dag",
+        params={"name": "analyst_role", "type": "role"},
+        headers=auth_header,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "nodes" in data
+    role_nodes = [n for n in data["nodes"] if n["type"] == "role"]
+    assert any(n["label"] == "analyst_role" for n in role_nodes)
+    # The highlighted node should be analyst_role
+    highlighted = [n for n in data["nodes"] if n.get("metadata", {}).get("highlight")]
+    assert any(n["label"] == "analyst_role" for n in highlighted)
+
+
+def test_user_inheritance_dag_missing_name(client, auth_header):
+    """inheritance-dag with empty name returns a DAG (not an error)."""
+    resp = client.get(
+        "/api/user/roles/inheritance-dag",
+        params={"name": "", "type": "user"},
+        headers=auth_header,
+    )
+    # Empty name is valid (defaults to ""), should still return 200 with nodes
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "nodes" in data

--- a/backend/tests/test_user_search_routes.py
+++ b/backend/tests/test_user_search_routes.py
@@ -1,0 +1,85 @@
+"""Tests for GET /api/user/search endpoint.
+
+Covers: user_search.py router — keyword search across catalogs, roles, databases, tables.
+"""
+from __future__ import annotations
+
+
+def test_user_search_basic(client, auth_header, query_map):
+    """Search with keyword matching table/database names returns results."""
+    # The default query_map has catalogs, databases, tables.
+    # The search uses LIKE %q%, which FakeConnection ignores (just returns all rows).
+    # But roles are matched by Python code: q.lower() in name.lower()
+    query_map["SHOW GRANTS FOR 'test_admin'"] = [
+        {"Grants": "GRANT 'analyst_role' TO 'test_admin'@'%'"},
+    ]
+    query_map["SHOW GRANTS FOR ROLE 'analyst_role'"] = []
+    resp = client.get("/api/user/search", params={"q": "analytics"}, headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    # Should find databases/tables matching "analytics"
+    assert len(data) >= 1
+    # Each result should have required fields
+    for item in data:
+        assert "name" in item
+        assert "type" in item
+        assert "path" in item
+
+
+def test_user_search_roles_included(client, auth_header, query_map):
+    """Roles matching the query keyword appear in results."""
+    # get_user_roles uses sys.role_edges → override to include analyst_role
+    query_map["SELECT FROM_ROLE FROM sys.role_edges WHERE TO_USER"] = [
+        {"FROM_ROLE": "analyst_role"},
+        {"FROM_ROLE": "public"},
+    ]
+    # get_parent_roles for analyst_role/public → no parents
+    query_map["SELECT FROM_ROLE FROM sys.role_edges WHERE TO_ROLE"] = []
+    resp = client.get("/api/user/search", params={"q": "analyst"}, headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    role_results = [r for r in data if r["type"] == "role"]
+    assert len(role_results) >= 1
+    assert any(r["name"] == "analyst_role" for r in role_results)
+
+
+def test_user_search_with_limit(client, auth_header, query_map):
+    """Respects the limit parameter."""
+    query_map["SHOW GRANTS FOR 'test_admin'"] = [
+        {"Grants": "GRANT 'analyst_role', 'public' TO 'test_admin'@'%'"},
+    ]
+    query_map["SHOW GRANTS FOR ROLE 'analyst_role'"] = []
+    query_map["SHOW GRANTS FOR ROLE 'public'"] = []
+    resp = client.get("/api/user/search", params={"q": "a", "limit": 1}, headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) <= 1
+
+
+def test_user_search_no_results(client, auth_header, query_map):
+    """Query that matches nothing returns empty list."""
+    # FakeConnection returns rows regardless of LIKE params, so roles matching
+    # is the only thing truly filtered. Use a nonsense query.
+    query_map["SHOW GRANTS FOR 'test_admin'"] = []
+    # Override tables/schemata to return nothing for this catalog search
+    query_map["SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE FROM information_schema.tables WHERE"] = []
+    query_map["SELECT SCHEMA_NAME FROM information_schema.schemata WHERE"] = []
+    resp = client.get("/api/user/search", params={"q": "zzz_nonexistent_xyz"}, headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    # Roles won't match, but tables/databases might still come from FakeConnection
+    # since it ignores SQL params. At minimum, we verify the response is a list.
+    assert isinstance(data, list)
+
+
+def test_user_search_deduplicates_results(client, auth_header, query_map):
+    """Results are deduplicated by path."""
+    # The search function deduplicates by path. With default query_map,
+    # multiple results will be returned but no duplicates.
+    query_map["SHOW GRANTS FOR 'test_admin'"] = []
+    resp = client.get("/api/user/search", params={"q": "analytics"}, headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    paths = [r["path"] for r in data]
+    assert len(paths) == len(set(paths)), "Duplicate paths found in results"

--- a/frontend/src/api/admin.test.ts
+++ b/frontend/src/api/admin.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockApiFetch = vi.fn();
+
+vi.mock("./client", () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+import {
+  getUserPrivileges,
+  getRolePrivileges,
+  getUserEffectivePrivileges,
+  getObjectPrivileges,
+  getRoles,
+  getRoleHierarchy,
+  getInheritanceDag,
+  getObjectHierarchy,
+  searchAll,
+  searchUsersRoles,
+} from "./admin";
+
+beforeEach(() => {
+  mockApiFetch.mockReset();
+  mockApiFetch.mockResolvedValue([]);
+});
+
+describe("admin API", () => {
+  it("getUserPrivileges calls correct endpoint", async () => {
+    await getUserPrivileges("admin");
+    expect(mockApiFetch).toHaveBeenCalledWith("/admin/privileges/user/admin", expect.any(Object));
+  });
+
+  it("getUserPrivileges encodes username", async () => {
+    await getUserPrivileges("user with spaces");
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/admin/privileges/user/user%20with%20spaces",
+      expect.any(Object),
+    );
+  });
+
+  it("getRolePrivileges calls correct endpoint", async () => {
+    await getRolePrivileges("db_admin");
+    expect(mockApiFetch).toHaveBeenCalledWith("/admin/privileges/role/db_admin", expect.any(Object));
+  });
+
+  it("getUserEffectivePrivileges calls correct endpoint", async () => {
+    await getUserEffectivePrivileges("root");
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/admin/privileges/user/root/effective",
+      expect.any(Object),
+    );
+  });
+
+  it("getObjectPrivileges builds query params", async () => {
+    await getObjectPrivileges("default", "analytics", "orders", "TABLE");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/admin/privileges/object?");
+    expect(url).toContain("catalog=default");
+    expect(url).toContain("database=analytics");
+    expect(url).toContain("name=orders");
+    expect(url).toContain("object_type=TABLE");
+  });
+
+  it("getObjectPrivileges omits undefined params", async () => {
+    await getObjectPrivileges("default");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("catalog=default");
+    expect(url).not.toContain("database=");
+    expect(url).not.toContain("name=");
+    expect(url).not.toContain("object_type=");
+  });
+
+  it("getRoles calls /admin/roles", async () => {
+    await getRoles();
+    expect(mockApiFetch).toHaveBeenCalledWith("/admin/roles");
+  });
+
+  it("getRoleHierarchy calls correct endpoint", async () => {
+    await getRoleHierarchy();
+    expect(mockApiFetch).toHaveBeenCalledWith("/admin/dag/role-hierarchy", expect.any(Object));
+  });
+
+  it("getInheritanceDag builds correct URL", async () => {
+    await getInheritanceDag("admin", "user");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/admin/roles/inheritance-dag?name=admin&type=user");
+  });
+
+  it("getObjectHierarchy with catalog param", async () => {
+    await getObjectHierarchy("my_catalog");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/admin/dag/object-hierarchy?catalog=my_catalog");
+  });
+
+  it("getObjectHierarchy without catalog param", async () => {
+    await getObjectHierarchy();
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toBe("/admin/dag/object-hierarchy");
+  });
+
+  it("searchAll builds correct URL with defaults", async () => {
+    await searchAll("orders");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/admin/search?q=orders&limit=50");
+  });
+
+  it("searchAll with custom limit", async () => {
+    await searchAll("test", 10);
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("limit=10");
+  });
+
+  it("searchUsersRoles builds correct URL", async () => {
+    await searchUsersRoles("admin");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/admin/search/users-roles?q=admin&limit=50");
+  });
+});

--- a/frontend/src/api/auth.test.ts
+++ b/frontend/src/api/auth.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockApiFetch = vi.fn();
+
+vi.mock("./client", () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+import { login, getMe, logoutApi } from "./auth";
+
+beforeEach(() => {
+  mockApiFetch.mockReset();
+  mockApiFetch.mockResolvedValue({});
+});
+
+describe("auth API", () => {
+  it("login sends POST with credentials", async () => {
+    const creds = { host: "10.0.0.1", port: 9030, username: "admin", password: "secret" };
+    await login(creds);
+    expect(mockApiFetch).toHaveBeenCalledWith("/auth/login", {
+      method: "POST",
+      body: JSON.stringify(creds),
+    });
+  });
+
+  it("getMe calls /auth/me", async () => {
+    await getMe();
+    expect(mockApiFetch).toHaveBeenCalledWith("/auth/me");
+  });
+
+  it("logoutApi sends POST to /auth/logout", async () => {
+    await logoutApi();
+    expect(mockApiFetch).toHaveBeenCalledWith("/auth/logout", { method: "POST" });
+  });
+});

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies before import
+const mockLogout = vi.fn();
+vi.mock("../stores/authStore", () => ({
+  useAuthStore: {
+    getState: vi.fn(() => ({
+      token: null,
+      logout: mockLogout,
+    })),
+  },
+}));
+
+vi.mock("../utils/toast", () => ({
+  showToast: vi.fn(),
+}));
+
+import { apiFetch } from "./client";
+import { showToast } from "../utils/toast";
+import { useAuthStore } from "../stores/authStore";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  localStorage.clear();
+  mockLogout.mockClear();
+  vi.mocked(showToast).mockClear();
+  vi.mocked(useAuthStore.getState).mockReturnValue({
+    token: null,
+    logout: mockLogout,
+  } as ReturnType<typeof useAuthStore.getState>);
+});
+
+describe("apiFetch", () => {
+  it("returns parsed JSON on successful 200 response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ data: "ok" })));
+
+    const result = await apiFetch<{ data: string }>("/test");
+    expect(result).toEqual({ data: "ok" });
+  });
+
+  it("prepends /api to the path", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse({}));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await apiFetch("/some/path");
+    expect(mockFetch).toHaveBeenCalledWith("/api/some/path", expect.any(Object));
+  });
+
+  it("injects Authorization header when sr_token exists in localStorage", async () => {
+    localStorage.setItem("sr_token", "my-jwt-token");
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse({}));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await apiFetch("/test");
+
+    const callHeaders = mockFetch.mock.calls[0][1].headers;
+    expect(callHeaders["Authorization"]).toBe("Bearer my-jwt-token");
+  });
+
+  it("does not include Authorization header when no token in localStorage", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse({}));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await apiFetch("/test");
+
+    const callHeaders = mockFetch.mock.calls[0][1].headers;
+    expect(callHeaders["Authorization"]).toBeUndefined();
+  });
+
+  it("shows error toast on 401 for /auth/login path", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ detail: "Invalid credentials" }, 401)),
+    );
+
+    await expect(apiFetch("/auth/login")).rejects.toThrow("Invalid credentials");
+    expect(showToast).toHaveBeenCalledWith("Invalid credentials", "error");
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it("calls logout on 401 for non-login paths", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ detail: "Unauthorized" }, 401)),
+    );
+
+    await expect(apiFetch("/user/roles")).rejects.toThrow();
+    expect(mockLogout).toHaveBeenCalledOnce();
+    expect(showToast).toHaveBeenCalledWith("Session expired. Please log in again.", "warning");
+  });
+
+  it("shows server error toast on 500+ status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ detail: "Internal failure" }, 500)),
+    );
+
+    await expect(apiFetch("/test")).rejects.toThrow();
+    expect(showToast).toHaveBeenCalledWith("Server error: Internal failure", "error");
+  });
+
+  it("throws without toast on 422 status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ detail: "Validation error" }, 422)),
+    );
+
+    await expect(apiFetch("/test")).rejects.toThrow("Validation error");
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it("shows network error toast on TypeError (network failure)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+    await expect(apiFetch("/test")).rejects.toThrow("Failed to fetch");
+    expect(showToast).toHaveBeenCalledWith("Network error: cannot reach server", "error");
+  });
+
+  it("rethrows AbortError without showing toast", async () => {
+    const abortError = new DOMException("The operation was aborted", "AbortError");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abortError));
+
+    await expect(apiFetch("/test")).rejects.toThrow(abortError);
+    expect(showToast).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/user.test.ts
+++ b/frontend/src/api/user.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockApiFetch = vi.fn();
+
+vi.mock("./client", () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+import {
+  getCatalogs,
+  getDatabases,
+  getTables,
+  getTableDetail,
+  getMyPermissions,
+  getUserEffectivePrivileges,
+  getRolePrivileges,
+  getObjectPrivileges,
+  getRoles,
+  getInheritanceDag,
+  getRoleHierarchy,
+  getObjectHierarchy,
+  searchAll,
+} from "./user";
+
+beforeEach(() => {
+  mockApiFetch.mockReset();
+  mockApiFetch.mockResolvedValue([]);
+});
+
+describe("user API", () => {
+  it("getCatalogs calls /user/objects/catalogs", async () => {
+    await getCatalogs();
+    expect(mockApiFetch).toHaveBeenCalledWith("/user/objects/catalogs");
+  });
+
+  it("getDatabases builds correct URL", async () => {
+    await getDatabases("default_catalog");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/user/objects/databases?catalog=default_catalog");
+  });
+
+  it("getTables builds correct URL with both params", async () => {
+    await getTables("default", "analytics");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/user/objects/tables?");
+    expect(url).toContain("catalog=default");
+    expect(url).toContain("database=analytics");
+  });
+
+  it("getTableDetail builds correct URL with all params", async () => {
+    await getTableDetail("default", "mydb", "orders");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/user/objects/table-detail?");
+    expect(url).toContain("catalog=default");
+    expect(url).toContain("database=mydb");
+    expect(url).toContain("table=orders");
+  });
+
+  it("getMyPermissions calls /user/my-permissions", async () => {
+    await getMyPermissions();
+    expect(mockApiFetch).toHaveBeenCalledWith("/user/my-permissions", expect.any(Object));
+  });
+
+  it("getUserEffectivePrivileges calls correct endpoint", async () => {
+    await getUserEffectivePrivileges("admin");
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/user/privileges/user/admin/effective",
+      expect.any(Object),
+    );
+  });
+
+  it("getRolePrivileges calls correct endpoint", async () => {
+    await getRolePrivileges("db_admin");
+    expect(mockApiFetch).toHaveBeenCalledWith("/user/privileges/role/db_admin", expect.any(Object));
+  });
+
+  it("getObjectPrivileges builds query params", async () => {
+    await getObjectPrivileges("cat", "db", "tbl", "TABLE");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/user/privileges/object?");
+    expect(url).toContain("catalog=cat");
+    expect(url).toContain("database=db");
+    expect(url).toContain("name=tbl");
+    expect(url).toContain("object_type=TABLE");
+  });
+
+  it("getObjectPrivileges omits undefined params", async () => {
+    await getObjectPrivileges("cat");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("catalog=cat");
+    expect(url).not.toContain("database=");
+    expect(url).not.toContain("name=");
+  });
+
+  it("getRoles calls /user/roles", async () => {
+    await getRoles();
+    expect(mockApiFetch).toHaveBeenCalledWith("/user/roles");
+  });
+
+  it("getInheritanceDag builds correct URL", async () => {
+    await getInheritanceDag("root", "role");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/user/roles/inheritance-dag?name=root&type=role");
+  });
+
+  it("getRoleHierarchy calls correct endpoint", async () => {
+    await getRoleHierarchy();
+    expect(mockApiFetch).toHaveBeenCalledWith("/user/dag/role-hierarchy", expect.any(Object));
+  });
+
+  it("getObjectHierarchy with catalog", async () => {
+    await getObjectHierarchy("my_catalog");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/user/dag/object-hierarchy?catalog=my_catalog");
+  });
+
+  it("getObjectHierarchy without catalog", async () => {
+    await getObjectHierarchy();
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toBe("/user/dag/object-hierarchy");
+  });
+
+  it("searchAll builds correct URL", async () => {
+    await searchAll("test_query");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/user/search?q=test_query&limit=50");
+  });
+
+  it("searchAll encodes special characters", async () => {
+    await searchAll("table with spaces");
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(url).toContain("q=table%20with%20spaces");
+  });
+});

--- a/frontend/src/components/auth/LoginForm.test.tsx
+++ b/frontend/src/components/auth/LoginForm.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "../../test/test-utils";
+import userEvent from "@testing-library/user-event";
+import LoginForm from "./LoginForm";
+
+// Mock nodeIcons to avoid SVG ?raw imports in test environment
+vi.mock("../dag/nodeIcons", () => ({
+  APP_LOGO_SVG: '<svg width="24" height="24"></svg>',
+  NODE_SVG_RAW: {},
+  colorizedSvg: () => "",
+}));
+
+const mockSetAuth = vi.fn();
+const mockSetConnectionInfo = vi.fn();
+
+vi.mock("../../stores/authStore", () => ({
+  useAuthStore: vi.fn(() => ({
+    setAuth: mockSetAuth,
+    setConnectionInfo: mockSetConnectionInfo,
+  })),
+}));
+
+const mockLogin = vi.fn();
+const mockGetMe = vi.fn();
+
+vi.mock("../../api/auth", () => ({
+  login: (...args: unknown[]) => mockLogin(...args),
+  getMe: (...args: unknown[]) => mockGetMe(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  mockLogin.mockReset();
+  mockGetMe.mockReset();
+});
+
+describe("LoginForm", () => {
+  it("renders all form fields", () => {
+    render(<LoginForm />);
+
+    expect(screen.getByPlaceholderText("192.168.1.100")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("9030")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("admin")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Password")).toBeInTheDocument();
+  });
+
+  it("has default port value 9030", () => {
+    render(<LoginForm />);
+
+    const portInput = screen.getByPlaceholderText("9030") as HTMLInputElement;
+    expect(portInput.value).toBe("9030");
+  });
+
+  it("renders the title and subtitle", () => {
+    render(<LoginForm />);
+
+    expect(screen.getByText("StarRocks Permission Manager")).toBeInTheDocument();
+    expect(
+      screen.getByText("Connect to a StarRocks cluster to visually explore permissions"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the submit button with 'Connect & Login' text", () => {
+    render(<LoginForm />);
+
+    expect(screen.getByRole("button", { name: "Connect & Login" })).toBeInTheDocument();
+  });
+
+  it("calls login, getMe, setConnectionInfo, and setAuth on successful submit", async () => {
+    const user = userEvent.setup();
+    mockLogin.mockResolvedValue({ token: "jwt-123", username: "admin", roles: [], default_role: null });
+    mockGetMe.mockResolvedValue({ username: "admin", roles: [], default_role: null, is_user_admin: true });
+
+    render(<LoginForm />);
+
+    await user.type(screen.getByPlaceholderText("192.168.1.100"), "10.0.0.1");
+    await user.clear(screen.getByPlaceholderText("9030"));
+    await user.type(screen.getByPlaceholderText("9030"), "9030");
+    await user.type(screen.getByPlaceholderText("admin"), "root");
+    await user.type(screen.getByPlaceholderText("Password"), "secret");
+    await user.click(screen.getByRole("button", { name: "Connect & Login" }));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith({
+        host: "10.0.0.1",
+        port: 9030,
+        username: "root",
+        password: "secret",
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockGetMe).toHaveBeenCalled();
+      expect(mockSetConnectionInfo).toHaveBeenCalledWith("10.0.0.1", 9030);
+      expect(mockSetAuth).toHaveBeenCalledWith("jwt-123", {
+        username: "admin",
+        roles: [],
+        default_role: null,
+        is_user_admin: true,
+      });
+    });
+  });
+
+  it("displays error message when login fails", async () => {
+    const user = userEvent.setup();
+    mockLogin.mockRejectedValue(new Error("Connection refused"));
+
+    render(<LoginForm />);
+
+    await user.type(screen.getByPlaceholderText("192.168.1.100"), "bad-host");
+    await user.type(screen.getByPlaceholderText("admin"), "root");
+    await user.type(screen.getByPlaceholderText("Password"), "wrong");
+    await user.click(screen.getByRole("button", { name: "Connect & Login" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Connection refused")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'Connecting...' while loading", async () => {
+    const user = userEvent.setup();
+    // Never resolve so the loading state persists
+    mockLogin.mockReturnValue(new Promise(() => {}));
+
+    render(<LoginForm />);
+
+    await user.type(screen.getByPlaceholderText("192.168.1.100"), "host");
+    await user.type(screen.getByPlaceholderText("admin"), "root");
+    await user.type(screen.getByPlaceholderText("Password"), "pass");
+    await user.click(screen.getByRole("button", { name: "Connect & Login" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Connecting...")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/common/ExportPngBtn.test.tsx
+++ b/frontend/src/components/common/ExportPngBtn.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "../../test/test-utils";
+import userEvent from "@testing-library/user-event";
+import ExportPngBtn from "./ExportPngBtn";
+
+// Mock colors
+vi.mock("../../utils/colors", () => ({
+  C: {
+    bg: "#0f172a",
+    card: "#1e293b",
+    borderLight: "#475569",
+    text2: "#94a3b8",
+    accent: "#3b82f6",
+  },
+}));
+
+describe("ExportPngBtn", () => {
+  it("renders PNG button text", () => {
+    render(<ExportPngBtn />);
+    expect(screen.getByText("PNG")).toBeInTheDocument();
+  });
+
+  it("renders as a button element", () => {
+    render(<ExportPngBtn />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("is not disabled by default", () => {
+    render(<ExportPngBtn />);
+    const btn = screen.getByRole("button");
+    expect(btn).not.toBeDisabled();
+  });
+
+  it("does nothing when no .react-flow element exists", async () => {
+    const user = userEvent.setup();
+    render(<ExportPngBtn />);
+    // No .react-flow element in the DOM, so clicking should not crash
+    await user.click(screen.getByRole("button"));
+    // Button text should still be "PNG" (not "Exporting...")
+    expect(screen.getByText("PNG")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/GrantTreeView.test.tsx
+++ b/frontend/src/components/common/GrantTreeView.test.tsx
@@ -58,10 +58,8 @@ describe("GrantTreeView", () => {
   });
 
   it("does not render title when not provided", () => {
-    const { container } = render(<GrantTreeView groups={sampleGroups} />);
-    // No p element with fontWeight 600 title style
-    const titleEl = container.querySelector("p");
-    // The first p would be scope content, not a title
+    render(<GrantTreeView groups={sampleGroups} />);
+    // No title rendered — only scope content
     expect(screen.queryByText(/grants\)/)).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/common/GrantTreeView.test.tsx
+++ b/frontend/src/components/common/GrantTreeView.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "../../test/test-utils";
+import GrantTreeView from "./GrantTreeView";
+import type { GrantDisplayGroup } from "../../utils/grantDisplay";
+
+// Mock InlineIcon which imports SVG via ?raw
+vi.mock("./InlineIcon", () => ({
+  default: ({ type, size }: { type: string; size?: number }) => (
+    <span data-testid={`icon-${type}`} data-size={size} />
+  ),
+}));
+
+// Mock colors
+vi.mock("../../utils/colors", () => ({
+  C: {
+    text1: "#e2e8f0",
+    text2: "#94a3b8",
+    text3: "#64748b",
+  },
+}));
+
+// Mock privColors
+vi.mock("../../utils/privColors", () => ({
+  getPrivColor: (priv: string) => {
+    if (priv === "SELECT") return { bg: "rgba(34,197,94,0.18)", fg: "#4ade80" };
+    if (priv === "INSERT") return { bg: "rgba(59,130,246,0.18)", fg: "#60a5fa" };
+    return { bg: "rgba(139,92,246,0.15)", fg: "#a78bfa" };
+  },
+}));
+
+const sampleGroups: GrantDisplayGroup[] = [
+  {
+    scope: "TABLE",
+    icon: "table",
+    items: [
+      { displayName: "orders", context: "default_catalog.analytics_db", privs: ["SELECT", "INSERT"] },
+      { displayName: "products", context: "default_catalog.analytics_db", privs: ["SELECT"] },
+    ],
+  },
+  {
+    scope: "DATABASE",
+    icon: "database",
+    items: [
+      { displayName: "analytics_db", context: "implicit access", privs: ["USAGE (implicit)"] },
+    ],
+  },
+];
+
+describe("GrantTreeView", () => {
+  it("renders title when provided", () => {
+    render(<GrantTreeView groups={sampleGroups} title="Effective Privileges" />);
+    expect(screen.getByText(/Effective Privileges/)).toBeInTheDocument();
+  });
+
+  it("renders title with total grant count", () => {
+    render(<GrantTreeView groups={sampleGroups} title="Privileges" totalGrants={5} />);
+    expect(screen.getByText("Privileges (5 grants)")).toBeInTheDocument();
+  });
+
+  it("does not render title when not provided", () => {
+    const { container } = render(<GrantTreeView groups={sampleGroups} />);
+    // No p element with fontWeight 600 title style
+    const titleEl = container.querySelector("p");
+    // The first p would be scope content, not a title
+    expect(screen.queryByText(/grants\)/)).not.toBeInTheDocument();
+  });
+
+  it("renders scope group headers with icons", () => {
+    render(<GrantTreeView groups={sampleGroups} />);
+    expect(screen.getByText("TABLE")).toBeInTheDocument();
+    expect(screen.getByText("DATABASE")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-table")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-database")).toBeInTheDocument();
+  });
+
+  it("renders item count per scope", () => {
+    render(<GrantTreeView groups={sampleGroups} />);
+    expect(screen.getByText("(2)")).toBeInTheDocument(); // TABLE has 2 items
+    expect(screen.getByText("(1)")).toBeInTheDocument(); // DATABASE has 1 item
+  });
+
+  it("renders privilege tags for items", () => {
+    render(<GrantTreeView groups={sampleGroups} />);
+    // SELECT appears twice (in orders and products), INSERT once
+    const selectTags = screen.getAllByText("SELECT");
+    expect(selectTags.length).toBe(2);
+    expect(screen.getByText("INSERT")).toBeInTheDocument();
+    expect(screen.getByText("USAGE (implicit)")).toBeInTheDocument();
+  });
+
+  it("renders display names for items", () => {
+    render(<GrantTreeView groups={sampleGroups} />);
+    expect(screen.getByText("orders")).toBeInTheDocument();
+    expect(screen.getByText("products")).toBeInTheDocument();
+    expect(screen.getByText("analytics_db")).toBeInTheDocument();
+  });
+
+  it("renders context for items", () => {
+    render(<GrantTreeView groups={sampleGroups} />);
+    const contexts = screen.getAllByText("default_catalog.analytics_db");
+    expect(contexts.length).toBe(2);
+    expect(screen.getByText("implicit access")).toBeInTheDocument();
+  });
+
+  it("renders 'Inherited from' badges when sourceRoles provided", () => {
+    render(<GrantTreeView groups={sampleGroups} sourceRoles={["db_admin", "analyst"]} />);
+    expect(screen.getByText("Inherited from")).toBeInTheDocument();
+    expect(screen.getByText("db_admin")).toBeInTheDocument();
+    expect(screen.getByText("analyst")).toBeInTheDocument();
+  });
+
+  it("does not render 'Inherited from' when sourceRoles is empty", () => {
+    render(<GrantTreeView groups={sampleGroups} sourceRoles={[]} />);
+    expect(screen.queryByText("Inherited from")).not.toBeInTheDocument();
+  });
+
+  it("renders 'No grants found' for empty groups", () => {
+    render(<GrantTreeView groups={[]} />);
+    expect(screen.getByText("No grants found")).toBeInTheDocument();
+  });
+
+  it("does not render 'No grants found' when groups are present", () => {
+    render(<GrantTreeView groups={sampleGroups} />);
+    expect(screen.queryByText("No grants found")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/InlineIcon.test.tsx
+++ b/frontend/src/components/common/InlineIcon.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "../../test/test-utils";
+import InlineIcon from "./InlineIcon";
+
+// Mock nodeIcons
+vi.mock("../dag/nodeIcons", () => ({
+  colorizedSvg: (type: string) => {
+    if (type === "unknown") return "";
+    return `<svg width="24" height="24"><circle cx="12" cy="12" r="10" stroke="${type}"/></svg>`;
+  },
+}));
+
+describe("InlineIcon", () => {
+  it("renders SVG content for known type", () => {
+    const { container } = render(<InlineIcon type="table" />);
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("returns null for unknown type (empty SVG)", () => {
+    const { container } = render(<InlineIcon type="unknown" />);
+    expect(container.querySelector("span")).toBeNull();
+  });
+
+  it("applies custom size to SVG", () => {
+    const { container } = render(<InlineIcon type="database" size={20} />);
+    const span = container.querySelector("span");
+    expect(span).not.toBeNull();
+    expect(span?.style.width).toBe("20px");
+    expect(span?.style.height).toBe("20px");
+  });
+
+  it("uses default size of 14", () => {
+    const { container } = render(<InlineIcon type="catalog" />);
+    const span = container.querySelector("span");
+    expect(span).not.toBeNull();
+    expect(span?.style.width).toBe("14px");
+    expect(span?.style.height).toBe("14px");
+  });
+
+  it("replaces width/height in the SVG string", () => {
+    const { container } = render(<InlineIcon type="table" size={16} />);
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("width")).toBe("16");
+    expect(svg?.getAttribute("height")).toBe("16");
+  });
+});

--- a/frontend/src/components/dag/CustomNode.test.tsx
+++ b/frontend/src/components/dag/CustomNode.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "../../test/test-utils";
+import CustomNode from "./CustomNode";
+
+// Mock @xyflow/react
+vi.mock("@xyflow/react", () => ({
+  Handle: ({ type }: { type: string }) => <div data-testid={`handle-${type}`} />,
+  Position: { Top: "top", Bottom: "bottom" },
+}));
+
+// Mock nodeIcons
+vi.mock("./nodeIcons", () => ({
+  colorizedSvg: (type: string, color?: string) => {
+    if (type === "unknown") return "";
+    return `<svg width="24" height="24" stroke="${color || "#000"}"><circle cx="12" cy="12" r="10"/></svg>`;
+  },
+  NODE_COLORS: {
+    system: "#6b7280",
+    catalog: "#3b82f6",
+    database: "#22c55e",
+    table: "#6366f1",
+    user: "#0ea5e9",
+    role: "#f97316",
+  },
+}));
+
+// Mock colors
+vi.mock("../../utils/colors", () => ({
+  C: {
+    card: "#1e293b",
+    text1: "#e2e8f0",
+  },
+}));
+
+function makeNodeProps(data: Record<string, unknown>) {
+  return {
+    id: "node-1",
+    data,
+    type: "custom",
+    selected: false,
+    isConnectable: true,
+    zIndex: 0,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
+    dragging: false,
+    dragHandle: undefined,
+    sourcePosition: undefined,
+    targetPosition: undefined,
+    parentId: undefined,
+    width: 168,
+    height: 40,
+    // biome-ignore lint: needed for xyflow compat
+  } as any;
+}
+
+describe("CustomNode", () => {
+  it("renders node label text", () => {
+    render(<CustomNode {...makeNodeProps({ label: "analytics_db", nodeType: "database" })} />);
+    expect(screen.getByText("analytics_db")).toBeInTheDocument();
+  });
+
+  it("renders with icon for known node type", () => {
+    const { container } = render(
+      <CustomNode {...makeNodeProps({ label: "orders", nodeType: "table" })} />,
+    );
+    // The SVG is injected via dangerouslySetInnerHTML
+    const svgSpan = container.querySelector("span[dangerouslysetinnerhtml]") || container.querySelector("svg");
+    // Check that the node renders svg content
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("has both source and target handles", () => {
+    render(<CustomNode {...makeNodeProps({ label: "test", nodeType: "table" })} />);
+    expect(screen.getByTestId("handle-target")).toBeInTheDocument();
+    expect(screen.getByTestId("handle-source")).toBeInTheDocument();
+  });
+
+  it("formats user node label by stripping quotes and host", () => {
+    render(<CustomNode {...makeNodeProps({ label: "'admin'@'%'", nodeType: "user" })} />);
+    expect(screen.getByText("admin")).toBeInTheDocument();
+    expect(screen.queryByText("'admin'@'%'")).not.toBeInTheDocument();
+  });
+
+  it("uses custom color when provided in data", () => {
+    const { container } = render(
+      <CustomNode {...makeNodeProps({ label: "custom", nodeType: "table", color: "#ff0000" })} />,
+    );
+    // jsdom converts hex to rgb; border: "2px solid #ff0000" becomes individual border properties
+    const allDivs = container.querySelectorAll("div");
+    let hasColor = false;
+    allDivs.forEach((div) => {
+      // Check the computed borderColor (jsdom converts to rgb)
+      if (div.style.borderColor === "rgb(255, 0, 0)" || div.style.borderColor === "#ff0000") {
+        hasColor = true;
+      }
+    });
+    expect(hasColor).toBe(true);
+  });
+
+  it("renders label without formatting for non-user types", () => {
+    render(<CustomNode {...makeNodeProps({ label: "my_table", nodeType: "table" })} />);
+    expect(screen.getByText("my_table")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dag/CustomNode.test.tsx
+++ b/frontend/src/components/dag/CustomNode.test.tsx
@@ -49,7 +49,7 @@ function makeNodeProps(data: Record<string, unknown>) {
     parentId: undefined,
     width: 168,
     height: 40,
-    // biome-ignore lint: needed for xyflow compat
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
 }
 
@@ -64,7 +64,6 @@ describe("CustomNode", () => {
       <CustomNode {...makeNodeProps({ label: "orders", nodeType: "table" })} />,
     );
     // The SVG is injected via dangerouslySetInnerHTML
-    const svgSpan = container.querySelector("span[dangerouslysetinnerhtml]") || container.querySelector("svg");
     // Check that the node renders svg content
     expect(container.querySelector("svg")).not.toBeNull();
   });

--- a/frontend/src/components/dag/GroupNode.test.tsx
+++ b/frontend/src/components/dag/GroupNode.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "../../test/test-utils";
+import GroupNode from "./GroupNode";
+
+// Mock @xyflow/react
+vi.mock("@xyflow/react", () => ({
+  Handle: ({ type }: { type: string }) => <div data-testid={`handle-${type}`} />,
+  Position: { Top: "top", Bottom: "bottom" },
+}));
+
+// Mock nodeIcons
+vi.mock("./nodeIcons", () => ({
+  colorizedSvg: (type: string) => {
+    if (type === "unknown") return "";
+    return `<svg width="24" height="24" stroke="#000"><circle cx="12" cy="12" r="10"/></svg>`;
+  },
+  NODE_COLORS: {
+    system: "#6b7280",
+    catalog: "#3b82f6",
+    database: "#22c55e",
+    table: "#6366f1",
+  },
+}));
+
+function makeNodeProps(data: Record<string, unknown>) {
+  return {
+    id: "group-1",
+    data,
+    type: "group",
+    selected: false,
+    isConnectable: true,
+    zIndex: 0,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
+    dragging: false,
+    dragHandle: undefined,
+    sourcePosition: undefined,
+    targetPosition: undefined,
+    parentId: undefined,
+    width: 200,
+    height: 100,
+    // biome-ignore lint: needed for xyflow compat
+  } as any;
+}
+
+describe("GroupNode", () => {
+  it("renders group label text", () => {
+    render(<GroupNode {...makeNodeProps({ label: "default_catalog", nodeType: "catalog" })} />);
+    expect(screen.getByText("default_catalog")).toBeInTheDocument();
+  });
+
+  it("has dashed border style", () => {
+    const { container } = render(
+      <GroupNode {...makeNodeProps({ label: "test_db", nodeType: "database" })} />,
+    );
+    // The outer div after handles should have dashed border
+    const groupDiv = container.querySelector("div[style]");
+    // Find the div with border containing "dashed"
+    const allDivs = container.querySelectorAll("div");
+    let hasDashed = false;
+    allDivs.forEach((div) => {
+      if (div.style.border?.includes("dashed")) hasDashed = true;
+    });
+    expect(hasDashed).toBe(true);
+  });
+
+  it("has both source and target handles", () => {
+    render(<GroupNode {...makeNodeProps({ label: "group", nodeType: "catalog" })} />);
+    expect(screen.getByTestId("handle-target")).toBeInTheDocument();
+    expect(screen.getByTestId("handle-source")).toBeInTheDocument();
+  });
+
+  it("uses custom dimensions when provided", () => {
+    const { container } = render(
+      <GroupNode {...makeNodeProps({ label: "wide", nodeType: "catalog", containerW: 400, containerH: 300 })} />,
+    );
+    const allDivs = container.querySelectorAll("div");
+    let found = false;
+    allDivs.forEach((div) => {
+      if (div.style.width === "400px" && div.style.height === "300px") found = true;
+    });
+    expect(found).toBe(true);
+  });
+
+  it("uses default dimensions when not provided", () => {
+    const { container } = render(
+      <GroupNode {...makeNodeProps({ label: "default", nodeType: "catalog" })} />,
+    );
+    const allDivs = container.querySelectorAll("div");
+    let found = false;
+    allDivs.forEach((div) => {
+      if (div.style.width === "200px" && div.style.height === "100px") found = true;
+    });
+    expect(found).toBe(true);
+  });
+
+  it("renders icon SVG content", () => {
+    const { container } = render(
+      <GroupNode {...makeNodeProps({ label: "system", nodeType: "system" })} />,
+    );
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/frontend/src/components/dag/GroupNode.test.tsx
+++ b/frontend/src/components/dag/GroupNode.test.tsx
@@ -39,7 +39,7 @@ function makeNodeProps(data: Record<string, unknown>) {
     parentId: undefined,
     width: 200,
     height: 100,
-    // biome-ignore lint: needed for xyflow compat
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
 }
 
@@ -54,7 +54,6 @@ describe("GroupNode", () => {
       <GroupNode {...makeNodeProps({ label: "test_db", nodeType: "database" })} />,
     );
     // The outer div after handles should have dashed border
-    const groupDiv = container.querySelector("div[style]");
     // Find the div with border containing "dashed"
     const allDivs = container.querySelectorAll("div");
     let hasDashed = false;

--- a/frontend/src/components/dag/dagLayout.test.ts
+++ b/frontend/src/components/dag/dagLayout.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+import { applyDagreLayout } from "./dagLayout";
+import type { Node, Edge } from "@xyflow/react";
+
+function makeNode(id: string, nodeType: string, opts?: { nodeRole?: string; label?: string }): Node {
+  return {
+    id,
+    position: { x: 0, y: 0 },
+    data: { label: opts?.label || id, nodeType, nodeRole: opts?.nodeRole },
+  };
+}
+
+function makeEdge(source: string, target: string): Edge {
+  return { id: `${source}-${target}`, source, target };
+}
+
+describe("applyDagreLayout", () => {
+  it("returns positioned nodes and edges for a simple hierarchy", () => {
+    const nodes = [
+      makeNode("system", "system", { label: "SYSTEM" }),
+      makeNode("cat1", "catalog", { label: "default_catalog" }),
+    ];
+    const edges = [makeEdge("system", "cat1")];
+
+    const result = applyDagreLayout(nodes, edges, "TB");
+    expect(result.nodes).toHaveLength(2);
+    expect(result.edges).toHaveLength(1);
+
+    // Each node should have a position
+    for (const n of result.nodes) {
+      expect(n.position).toBeDefined();
+      expect(typeof n.position.x).toBe("number");
+      expect(typeof n.position.y).toBe("number");
+    }
+  });
+
+  it("assigns type=custom to regular nodes", () => {
+    const nodes = [makeNode("n1", "table", { label: "orders" })];
+    const result = applyDagreLayout(nodes, [], "TB");
+    expect(result.nodes[0].type).toBe("custom");
+  });
+
+  it("handles empty graph", () => {
+    const result = applyDagreLayout([], [], "TB");
+    expect(result.nodes).toHaveLength(0);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it("positions parent above child in TB layout", () => {
+    const nodes = [
+      makeNode("system", "system", { label: "SYSTEM" }),
+      makeNode("cat1", "catalog", { label: "default_catalog" }),
+      makeNode("db1", "database", { label: "mydb" }),
+    ];
+    const edges = [makeEdge("system", "cat1"), makeEdge("cat1", "db1")];
+
+    const result = applyDagreLayout(nodes, edges, "TB");
+    const sysNode = result.nodes.find((n) => n.id === "system")!;
+    const catNode = result.nodes.find((n) => n.id === "cat1")!;
+    const dbNode = result.nodes.find((n) => n.id === "db1")!;
+
+    // In TB layout, parent Y should be less than child Y
+    expect(sysNode.position.y).toBeLessThan(catNode.position.y);
+    expect(catNode.position.y).toBeLessThan(dbNode.position.y);
+  });
+
+  it("handles group nodes with children", () => {
+    const nodes = [
+      makeNode("parent", "database", { label: "mydb" }),
+      makeNode("group1", "table", { label: "Tables", nodeRole: "group" }),
+      makeNode("t1", "table", { label: "orders" }),
+      makeNode("t2", "table", { label: "users" }),
+    ];
+    const edges = [
+      makeEdge("parent", "group1"),
+      makeEdge("group1", "t1"),
+      makeEdge("group1", "t2"),
+    ];
+
+    const result = applyDagreLayout(nodes, edges, "TB");
+    // Should have 4 nodes total
+    expect(result.nodes).toHaveLength(4);
+
+    // Group node should have type "group"
+    const groupNode = result.nodes.find((n) => n.id === "group1");
+    expect(groupNode?.type).toBe("group");
+
+    // Children should be parented to group
+    const child1 = result.nodes.find((n) => n.id === "t1");
+    const child2 = result.nodes.find((n) => n.id === "t2");
+    expect(child1?.parentId).toBe("group1");
+    expect(child2?.parentId).toBe("group1");
+  });
+
+  it("assigns container dimensions to group nodes", () => {
+    const nodes = [
+      makeNode("group1", "table", { label: "Tables", nodeRole: "group" }),
+      makeNode("t1", "table", { label: "orders" }),
+      makeNode("t2", "table", { label: "users" }),
+      makeNode("t3", "table", { label: "products" }),
+      makeNode("t4", "table", { label: "categories" }),
+    ];
+    const edges = [
+      makeEdge("group1", "t1"),
+      makeEdge("group1", "t2"),
+      makeEdge("group1", "t3"),
+      makeEdge("group1", "t4"),
+    ];
+
+    const result = applyDagreLayout(nodes, edges, "TB");
+    const groupNode = result.nodes.find((n) => n.id === "group1");
+    expect(groupNode).toBeDefined();
+    // Group should have containerW and containerH in data
+    const data = groupNode!.data as Record<string, unknown>;
+    expect(data.containerW).toBeGreaterThan(0);
+    expect(data.containerH).toBeGreaterThan(0);
+    // Group should have width/height style
+    expect(groupNode!.style?.width).toBeGreaterThan(0);
+    expect(groupNode!.style?.height).toBeGreaterThan(0);
+  });
+
+  it("handles role map layout with role and user nodes", () => {
+    const nodes = [
+      makeNode("root", "role", { label: "root" }),
+      makeNode("db_admin", "role", { label: "db_admin" }),
+      makeNode("custom_role", "role", { label: "custom_role" }),
+      makeNode("u1", "user", { label: "'admin'@'%'" }),
+    ];
+    const edges = [
+      makeEdge("root", "db_admin"),
+      makeEdge("db_admin", "custom_role"),
+      makeEdge("custom_role", "u1"),
+    ];
+
+    const result = applyDagreLayout(nodes, edges, "TB");
+    expect(result.nodes).toHaveLength(4);
+
+    // All nodes should have positions
+    for (const n of result.nodes) {
+      expect(typeof n.position.x).toBe("number");
+      expect(typeof n.position.y).toBe("number");
+      expect(isFinite(n.position.x)).toBe(true);
+      expect(isFinite(n.position.y)).toBe(true);
+    }
+  });
+
+  it("handles multiple disconnected components in role map", () => {
+    const nodes = [
+      makeNode("r1", "role", { label: "role_a" }),
+      makeNode("u1", "user", { label: "user_a" }),
+      makeNode("r2", "role", { label: "role_b" }),
+      makeNode("u2", "user", { label: "user_b" }),
+    ];
+    const edges = [
+      makeEdge("r1", "u1"),
+      makeEdge("r2", "u2"),
+    ];
+
+    const result = applyDagreLayout(nodes, edges, "TB");
+    expect(result.nodes).toHaveLength(4);
+
+    // Components should be placed side by side (different X ranges)
+    const r1 = result.nodes.find((n) => n.id === "r1")!;
+    const r2 = result.nodes.find((n) => n.id === "r2")!;
+    // They should have different X positions since they're separate components
+    expect(r1.position.x).not.toBe(r2.position.x);
+  });
+
+  it("preserves edge data in output", () => {
+    const nodes = [
+      makeNode("a", "catalog", { label: "a" }),
+      makeNode("b", "database", { label: "b" }),
+    ];
+    const edges: Edge[] = [{ id: "a-b", source: "a", target: "b", data: { custom: true } }];
+
+    const result = applyDagreLayout(nodes, edges, "TB");
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].source).toBe("a");
+    expect(result.edges[0].target).toBe("b");
+  });
+
+  it("children have extent=parent", () => {
+    const nodes = [
+      makeNode("group1", "table", { label: "Tables", nodeRole: "group" }),
+      makeNode("t1", "table", { label: "orders" }),
+    ];
+    const edges = [makeEdge("group1", "t1")];
+
+    const result = applyDagreLayout(nodes, edges, "TB");
+    const child = result.nodes.find((n) => n.id === "t1");
+    expect(child?.extent).toBe("parent");
+  });
+
+  it("handles large number of nodes without error", () => {
+    const nodes: Node[] = [];
+    const edges: Edge[] = [];
+    const root = makeNode("root", "system", { label: "SYSTEM" });
+    nodes.push(root);
+    for (let i = 0; i < 100; i++) {
+      const n = makeNode(`t${i}`, "table", { label: `table_${i}` });
+      nodes.push(n);
+      edges.push(makeEdge("root", n.id));
+    }
+
+    const result = applyDagreLayout(nodes, edges, "TB");
+    expect(result.nodes).toHaveLength(101);
+  });
+});

--- a/frontend/src/components/dag/nodeIcons.test.ts
+++ b/frontend/src/components/dag/nodeIcons.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock all SVG ?raw imports before importing the module
+vi.mock("../../../icons/system.svg?raw", () => ({ default: '<svg width="24" height="24" stroke="#000"><circle cx="12" cy="12" r="10"/></svg>' }));
+vi.mock("../../../icons/catalog.svg?raw", () => ({ default: '<svg width="24" height="24" stroke="#000"><rect x="4" y="4" width="16" height="16"/></svg>' }));
+vi.mock("../../../icons/database.svg?raw", () => ({ default: '<svg width="24" height="24" stroke="#000"><ellipse cx="12" cy="12" rx="10" ry="6"/></svg>' }));
+vi.mock("../../../icons/table.svg?raw", () => ({ default: '<svg width="24" height="24" stroke="#000"><line x1="0" y1="12" x2="24" y2="12"/></svg>' }));
+vi.mock("../../../icons/view.svg?raw", () => ({ default: '<svg width="24" height="24" stroke="#000"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/></svg>' }));
+vi.mock("../../../icons/mv.svg?raw", () => ({ default: '<svg width="24" height="24" stroke="#000"><polygon points="12,2 22,22 2,22"/></svg>' }));
+vi.mock("../../../icons/function.svg?raw", () => ({ default: '<svg width="24" height="24" stroke="#000"><text>f(x)</text></svg>' }));
+vi.mock("../../../icons/user.svg?raw", () => ({ default: '<svg width="24" height="24" stroke="#000"><circle cx="12" cy="8" r="5"/></svg>' }));
+vi.mock("../../../icons/role.svg?raw", () => ({ default: '<svg width="24" height="24" stroke="#000" fill="blue"><rect x="6" y="6" width="12" height="12"/></svg>' }));
+vi.mock("../../../icons/app-logo.svg?raw", () => ({ default: '<svg width="24" height="24"><circle cx="12" cy="12" r="10"/></svg>' }));
+
+import { NODE_SVG_RAW, APP_LOGO_SVG, NODE_COLORS, ROLE_CATEGORY_COLORS, EDGE_COLORS, colorizedSvg } from "./nodeIcons";
+
+beforeEach(() => {
+  // Clear the internal SVG cache by calling with unique types each time would not work,
+  // but we can test the function behavior
+});
+
+describe("NODE_SVG_RAW", () => {
+  it("contains all expected node types", () => {
+    const expectedTypes = ["system", "catalog", "database", "table", "view", "mv", "function", "user", "role"];
+    for (const type of expectedTypes) {
+      expect(NODE_SVG_RAW[type]).toBeDefined();
+      expect(typeof NODE_SVG_RAW[type]).toBe("string");
+    }
+  });
+
+  it("all SVG strings contain svg element", () => {
+    for (const [, svg] of Object.entries(NODE_SVG_RAW)) {
+      expect(svg).toContain("<svg");
+    }
+  });
+});
+
+describe("APP_LOGO_SVG", () => {
+  it("is a non-empty string containing svg", () => {
+    expect(typeof APP_LOGO_SVG).toBe("string");
+    expect(APP_LOGO_SVG.length).toBeGreaterThan(0);
+    expect(APP_LOGO_SVG).toContain("<svg");
+  });
+});
+
+describe("NODE_COLORS", () => {
+  it("has colors for all node types", () => {
+    const expectedTypes = ["system", "catalog", "database", "table", "view", "mv", "function", "user", "role"];
+    for (const type of expectedTypes) {
+      expect(NODE_COLORS[type]).toBeDefined();
+      expect(NODE_COLORS[type]).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+});
+
+describe("ROLE_CATEGORY_COLORS", () => {
+  it("has colors for root, builtin, and custom", () => {
+    expect(ROLE_CATEGORY_COLORS.root).toBeDefined();
+    expect(ROLE_CATEGORY_COLORS.builtin).toBeDefined();
+    expect(ROLE_CATEGORY_COLORS.custom).toBeDefined();
+  });
+});
+
+describe("EDGE_COLORS", () => {
+  it("has colors for common edge types", () => {
+    expect(EDGE_COLORS.hierarchy).toBeDefined();
+    expect(EDGE_COLORS.assignment).toBeDefined();
+    expect(EDGE_COLORS.inheritance).toBeDefined();
+  });
+});
+
+describe("colorizedSvg", () => {
+  it("replaces stroke color in SVG string", () => {
+    const result = colorizedSvg("system");
+    expect(result).toContain('stroke="#6b7280"');
+    expect(result).not.toContain('stroke="#000"');
+  });
+
+  it("uses override color when provided", () => {
+    const result = colorizedSvg("catalog", "#ff0000");
+    expect(result).toContain('stroke="#ff0000"');
+  });
+
+  it("replaces fill color (but not fill=none)", () => {
+    // role SVG has fill="blue"
+    const result = colorizedSvg("role");
+    const roleColor = NODE_COLORS.role; // #f97316
+    expect(result).toContain(`fill="${roleColor}"`);
+    expect(result).not.toContain('fill="blue"');
+  });
+
+  it("returns empty string for unknown type", () => {
+    const result = colorizedSvg("nonexistent");
+    expect(result).toBe("");
+  });
+
+  it("returns cached result on second call with same args", () => {
+    const result1 = colorizedSvg("table");
+    const result2 = colorizedSvg("table");
+    expect(result1).toBe(result2);
+  });
+
+  it("uses default gray for unknown type with NODE_COLORS", () => {
+    // When type is unknown, color defaults to #6b7280 but raw SVG is also undefined
+    const result = colorizedSvg("unknown_type");
+    expect(result).toBe("");
+  });
+});

--- a/frontend/src/components/layout/Header.test.tsx
+++ b/frontend/src/components/layout/Header.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "../../test/test-utils";
+import userEvent from "@testing-library/user-event";
+import Header from "./Header";
+
+// Mock nodeIcons to avoid SVG ?raw imports
+vi.mock("../dag/nodeIcons", () => ({
+  APP_LOGO_SVG: '<svg width="24" height="24"><circle cx="12" cy="12" r="10"/></svg>',
+  NODE_SVG_RAW: {},
+  NODE_COLORS: {},
+  colorizedSvg: () => "",
+}));
+
+// Mock colors
+vi.mock("../../utils/colors", () => ({
+  C: {
+    card: "#1e293b",
+    borderLight: "#475569",
+    text1: "#e2e8f0",
+    text2: "#94a3b8",
+  },
+}));
+
+const mockLogout = vi.fn();
+
+vi.mock("../../stores/authStore", () => ({
+  useAuthStore: vi.fn(() => ({
+    user: { username: "admin", roles: ["root"], default_role: "root", is_user_admin: true },
+    connectionInfo: { host: "10.0.0.1", port: 9030 },
+    logout: mockLogout,
+  })),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Header", () => {
+  it("renders app title", () => {
+    render(<Header />);
+    expect(screen.getByText("StarRocks Permission Manager")).toBeInTheDocument();
+  });
+
+  it("renders username from store", () => {
+    render(<Header />);
+    expect(screen.getByText("admin")).toBeInTheDocument();
+  });
+
+  it("renders connection info (host:port)", () => {
+    render(<Header />);
+    expect(screen.getByText(/@10\.0\.0\.1:9030/)).toBeInTheDocument();
+  });
+
+  it("renders logout button", () => {
+    render(<Header />);
+    expect(screen.getByText("Logout")).toBeInTheDocument();
+  });
+
+  it("logout button calls store.logout()", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByText("Logout"));
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders when connectionInfo is null", async () => {
+    // Re-mock with null connectionInfo
+    const { useAuthStore } = await import("../../stores/authStore");
+    (useAuthStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      user: { username: "viewer", roles: [], default_role: null, is_user_admin: false },
+      connectionInfo: null,
+      logout: mockLogout,
+    });
+
+    render(<Header />);
+    expect(screen.getByText("viewer")).toBeInTheDocument();
+    // No @host:port text
+    expect(screen.queryByText(/@/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/panels/GroupDetailPanel.test.tsx
+++ b/frontend/src/components/panels/GroupDetailPanel.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "../../test/test-utils";
+import userEvent from "@testing-library/user-event";
+import GroupDetailPanel from "./GroupDetailPanel";
+
+// Mock nodeIcons
+vi.mock("../dag/nodeIcons", () => ({
+  NODE_COLORS: {
+    system: "#6b7280",
+    catalog: "#3b82f6",
+    database: "#22c55e",
+    table: "#6366f1",
+  },
+  colorizedSvg: () => "",
+  NODE_SVG_RAW: {},
+}));
+
+// Mock InlineIcon
+vi.mock("../common/InlineIcon", () => ({
+  default: ({ type }: { type: string }) => <span data-testid={`icon-${type}`} />,
+}));
+
+// Mock colors
+vi.mock("../../utils/colors", () => ({
+  C: {
+    bg: "#0f172a",
+    card: "#1e293b",
+    border: "#334155",
+    borderLight: "#475569",
+    text1: "#e2e8f0",
+    text2: "#94a3b8",
+    text3: "#64748b",
+    accent: "#3b82f6",
+  },
+}));
+
+const mockSetSelectedNode = vi.fn();
+const mockSetPanelMode = vi.fn();
+
+vi.mock("../../stores/dagStore", () => ({
+  useDagStore: vi.fn(() => ({
+    selectedNode: {
+      id: "group-1",
+      label: "Tables",
+      type: "table",
+      color: null,
+    },
+    groupChildren: [
+      { id: "t1", label: "orders", type: "table" },
+      { id: "t2", label: "products", type: "table" },
+      { id: "t3", label: "users", type: "table" },
+    ],
+    setSelectedNode: mockSetSelectedNode,
+    setPanelMode: mockSetPanelMode,
+  })),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GroupDetailPanel", () => {
+  it("renders group label", () => {
+    render(<GroupDetailPanel />);
+    expect(screen.getByText("Tables")).toBeInTheDocument();
+  });
+
+  it("renders type badge", () => {
+    render(<GroupDetailPanel />);
+    expect(screen.getByText("TABLE Group")).toBeInTheDocument();
+  });
+
+  it("renders object count", () => {
+    render(<GroupDetailPanel />);
+    expect(screen.getByText("3 Objects")).toBeInTheDocument();
+  });
+
+  it("renders child items", () => {
+    render(<GroupDetailPanel />);
+    expect(screen.getByText("orders")).toBeInTheDocument();
+    expect(screen.getByText("products")).toBeInTheDocument();
+    expect(screen.getByText("users")).toBeInTheDocument();
+  });
+
+  it("clicking a child calls setSelectedNode and setPanelMode", async () => {
+    const user = userEvent.setup();
+    render(<GroupDetailPanel />);
+    await user.click(screen.getByText("orders"));
+    expect(mockSetSelectedNode).toHaveBeenCalledWith({ id: "t1", label: "orders", type: "table" });
+    expect(mockSetPanelMode).toHaveBeenCalledWith("object");
+  });
+
+  it("renders icons for the group and children", () => {
+    render(<GroupDetailPanel />);
+    // 1 header icon + 3 child icons = 4 total
+    const icons = screen.getAllByTestId("icon-table");
+    expect(icons.length).toBe(4);
+  });
+
+  it("returns null when selectedNode is null", async () => {
+    const { useDagStore } = await import("../../stores/dagStore");
+    (useDagStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      selectedNode: null,
+      groupChildren: [],
+      setSelectedNode: mockSetSelectedNode,
+      setPanelMode: mockSetPanelMode,
+    });
+
+    const { container } = render(<GroupDetailPanel />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/frontend/src/components/tabs/PermissionMatrix.test.tsx
+++ b/frontend/src/components/tabs/PermissionMatrix.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "../../test/test-utils";
+import { GranteeName, PermissionMatrixView } from "./PermissionMatrix";
+import type { PrivilegeGrant } from "../../types";
+
+// Mock InlineIcon to avoid SVG ?raw imports
+vi.mock("../common/InlineIcon", () => ({
+  default: ({ type }: { type: string }) => <span data-testid={`icon-${type}`} />,
+}));
+
+function makeGrant(overrides: Partial<PrivilegeGrant> = {}): PrivilegeGrant {
+  return {
+    grantee: "test_user",
+    grantee_type: "USER",
+    object_catalog: "default_catalog",
+    object_database: "test_db",
+    object_name: "my_table",
+    object_type: "TABLE",
+    privilege_type: "SELECT",
+    is_grantable: false,
+    source: "direct",
+    ...overrides,
+  };
+}
+
+describe("GranteeName", () => {
+  it("renders a simple user name", () => {
+    const grants = [makeGrant({ grantee: "admin", grantee_type: "USER" })];
+    render(<GranteeName name="admin" grants={grants} />);
+
+    expect(screen.getByText("admin")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-user")).toBeInTheDocument();
+  });
+
+  it("parses 'user'@'host' format and displays only the username", () => {
+    const grants = [makeGrant({ grantee: "'root'@'%'", grantee_type: "USER" })];
+    render(<GranteeName name="'root'@'%'" grants={grants} />);
+
+    expect(screen.getByText("root")).toBeInTheDocument();
+    // '%' host maps to "ALL CIDR"
+    expect(screen.getByText("(ALL CIDR)")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-user")).toBeInTheDocument();
+  });
+
+  it("renders role type with role icon", () => {
+    const grants = [makeGrant({ grantee: "db_admin", grantee_type: "ROLE" })];
+    render(<GranteeName name="db_admin" grants={grants} />);
+
+    expect(screen.getByText("db_admin")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-role")).toBeInTheDocument();
+  });
+
+  it("renders user@host with specific host showing /32 suffix", () => {
+    const grants = [makeGrant({ grantee: "'app'@'10.0.0.1'", grantee_type: "USER" })];
+    render(<GranteeName name="'app'@'10.0.0.1'" grants={grants} />);
+
+    expect(screen.getByText("app")).toBeInTheDocument();
+    expect(screen.getByText("(10.0.0.1/32)")).toBeInTheDocument();
+  });
+});
+
+describe("PermissionMatrixView", () => {
+  it("renders privilege columns for TABLE type", () => {
+    const grants = [makeGrant({ privilege_type: "SELECT", source: "direct" })];
+    render(<PermissionMatrixView grants={grants} objectType="TABLE" />);
+
+    // TABLE columns: CREATE TABLE → "CREATE", SELECT, INSERT, UPDATE, DELETE, ALTER, DROP, EXPORT
+    expect(screen.getByText("Grantee")).toBeInTheDocument();
+    expect(screen.getByText("SELECT")).toBeInTheDocument();
+    expect(screen.getByText("INSERT")).toBeInTheDocument();
+    expect(screen.getByText("DELETE")).toBeInTheDocument();
+  });
+
+  it("shows 'D' indicator for direct grants", () => {
+    const grants = [makeGrant({ privilege_type: "SELECT", source: "direct" })];
+    render(<PermissionMatrixView grants={grants} objectType="TABLE" />);
+
+    const badges = screen.getAllByText("D");
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows 'I' indicator for inherited grants", () => {
+    const grants = [makeGrant({ privilege_type: "SELECT", source: "inherited" })];
+    render(<PermissionMatrixView grants={grants} objectType="TABLE" />);
+
+    const badges = screen.getAllByText("I");
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows empty state when no grants are provided", () => {
+    render(<PermissionMatrixView grants={[]} objectType="TABLE" />);
+
+    expect(screen.getByText("No privilege grants found")).toBeInTheDocument();
+  });
+
+  it("renders multiple grantees in separate rows", () => {
+    const grants = [
+      makeGrant({ grantee: "user_a", privilege_type: "SELECT", source: "direct" }),
+      makeGrant({ grantee: "user_b", privilege_type: "INSERT", source: "direct" }),
+    ];
+    render(<PermissionMatrixView grants={grants} objectType="TABLE" />);
+
+    expect(screen.getByText("user_a")).toBeInTheDocument();
+    expect(screen.getByText("user_b")).toBeInTheDocument();
+  });
+
+  it("renders 'All Roles' and 'All Users' rows when public role has grants", () => {
+    const grants = [
+      makeGrant({ grantee: "public", grantee_type: "ROLE", privilege_type: "SELECT", source: "direct" }),
+      makeGrant({ grantee: "admin_user", grantee_type: "USER", privilege_type: "INSERT", source: "direct" }),
+    ];
+    render(<PermissionMatrixView grants={grants} objectType="TABLE" />);
+
+    expect(screen.getByText("All Roles")).toBeInTheDocument();
+    expect(screen.getByText("All Users")).toBeInTheDocument();
+    // admin_user should still appear since they have INSERT (not just public's SELECT)
+    expect(screen.getByText("admin_user")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/tabs/inventory-ui.test.tsx
+++ b/frontend/src/components/tabs/inventory-ui.test.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "../../test/test-utils";
+import userEvent from "@testing-library/user-event";
+import {
+  SearchInput,
+  Chip,
+  Badge,
+  SectionLabel,
+  Loader,
+  TH,
+  SortTH,
+  TD,
+  MetaItem,
+} from "./inventory-ui";
+
+// Mock InlineIcon
+vi.mock("../common/InlineIcon", () => ({
+  default: ({ type, size }: { type: string; size?: number }) => (
+    <span data-testid={`icon-${type}`} data-size={size} />
+  ),
+}));
+
+// Mock inventory-helpers C and formatSQL
+vi.mock("../../utils/inventory-helpers", () => ({
+  C: {
+    bg: "#0f172a",
+    card: "#1e293b",
+    border: "#334155",
+    borderLight: "#475569",
+    text1: "#e2e8f0",
+    text2: "#94a3b8",
+    text3: "#64748b",
+    accent: "#3b82f6",
+  },
+  formatSQL: (sql: string) => sql,
+}));
+
+describe("SearchInput", () => {
+  it("renders with placeholder text", () => {
+    render(<SearchInput value="" onChange={() => {}} />);
+    expect(screen.getByPlaceholderText("Filter by name...")).toBeInTheDocument();
+  });
+
+  it("displays current value", () => {
+    render(<SearchInput value="test-query" onChange={() => {}} />);
+    const input = screen.getByPlaceholderText("Filter by name...") as HTMLInputElement;
+    expect(input.value).toBe("test-query");
+  });
+
+  it("calls onChange when typing", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<SearchInput value="" onChange={handleChange} />);
+    const input = screen.getByPlaceholderText("Filter by name...");
+    await user.type(input, "abc");
+    expect(handleChange).toHaveBeenCalledTimes(3);
+    expect(handleChange).toHaveBeenLastCalledWith("c");
+  });
+
+  it("shows clear button when value is non-empty", () => {
+    render(<SearchInput value="something" onChange={() => {}} />);
+    // The clear button renders a times character
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("does not show clear button when value is empty", () => {
+    render(<SearchInput value="" onChange={() => {}} />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("calls onChange with empty string when clear is clicked", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<SearchInput value="test" onChange={handleChange} />);
+    await user.click(screen.getByRole("button"));
+    expect(handleChange).toHaveBeenCalledWith("");
+  });
+});
+
+describe("Chip", () => {
+  it("renders label text", () => {
+    render(<Chip label="Tables" active={false} onClick={() => {}} />);
+    expect(screen.getByText("Tables")).toBeInTheDocument();
+  });
+
+  it("calls onClick when clicked", async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<Chip label="Roles" active={false} onClick={handleClick} />);
+    await user.click(screen.getByText("Roles"));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders as a button element", () => {
+    render(<Chip label="Views" active={true} onClick={() => {}} />);
+    expect(screen.getByRole("button", { name: "Views" })).toBeInTheDocument();
+  });
+});
+
+describe("Badge", () => {
+  it("renders text content", () => {
+    render(<Badge text="ADMIN" color="#3b82f6" />);
+    expect(screen.getByText("ADMIN")).toBeInTheDocument();
+  });
+
+  it("renders as uppercase styled span", () => {
+    const { container } = render(<Badge text="builtin" color="#6366f1" />);
+    const span = container.querySelector("span");
+    expect(span).toBeInTheDocument();
+    expect(span?.style.textTransform).toBe("uppercase");
+  });
+});
+
+describe("SectionLabel", () => {
+  it("renders children text", () => {
+    render(<SectionLabel>Permissions</SectionLabel>);
+    expect(screen.getByText("Permissions")).toBeInTheDocument();
+  });
+});
+
+describe("Loader", () => {
+  it("renders loading text", () => {
+    render(<Loader />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+});
+
+describe("TH", () => {
+  it("renders header cell with text", () => {
+    render(
+      <table><thead><tr><TH>Name</TH></tr></thead></table>,
+    );
+    expect(screen.getByText("Name")).toBeInTheDocument();
+  });
+
+  it("renders as th element", () => {
+    render(
+      <table><thead><tr><TH>Type</TH></tr></thead></table>,
+    );
+    const th = screen.getByText("Type").closest("th");
+    expect(th).toBeInTheDocument();
+  });
+});
+
+describe("SortTH", () => {
+  it("renders header text", () => {
+    render(
+      <table><thead><tr><SortTH label="Name" dir="asc" onToggle={() => {}} /></tr></thead></table>,
+    );
+    expect(screen.getByText("Name")).toBeInTheDocument();
+  });
+
+  it("shows ascending arrow when dir is asc", () => {
+    render(
+      <table><thead><tr><SortTH label="Name" dir="asc" onToggle={() => {}} /></tr></thead></table>,
+    );
+    expect(screen.getByText("▲")).toBeInTheDocument();
+  });
+
+  it("shows descending arrow when dir is desc", () => {
+    render(
+      <table><thead><tr><SortTH label="Name" dir="desc" onToggle={() => {}} /></tr></thead></table>,
+    );
+    expect(screen.getByText("▼")).toBeInTheDocument();
+  });
+
+  it("calls onToggle when clicked", async () => {
+    const user = userEvent.setup();
+    const handleToggle = vi.fn();
+    render(
+      <table><thead><tr><SortTH label="Name" dir="asc" onToggle={handleToggle} /></tr></thead></table>,
+    );
+    await user.click(screen.getByText("Name"));
+    expect(handleToggle).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("TD", () => {
+  it("renders data cell with text", () => {
+    render(
+      <table><tbody><tr><TD>Cell Value</TD></tr></tbody></table>,
+    );
+    expect(screen.getByText("Cell Value")).toBeInTheDocument();
+  });
+
+  it("renders as td element", () => {
+    render(
+      <table><tbody><tr><TD>Data</TD></tr></tbody></table>,
+    );
+    const td = screen.getByText("Data").closest("td");
+    expect(td).toBeInTheDocument();
+  });
+});
+
+describe("MetaItem", () => {
+  it("renders label and plain text value", () => {
+    render(
+      <table><tbody><tr><MetaItem label="Engine" value="OLAP" /></tr></tbody></table>,
+    );
+    expect(screen.getByText("Engine")).toBeInTheDocument();
+    expect(screen.getByText("OLAP")).toBeInTheDocument();
+  });
+
+  it("renders creator format with name and badge", () => {
+    render(
+      <table><tbody><tr><MetaItem label="Creator" value="__CREATOR__root__system" /></tr></tbody></table>,
+    );
+    expect(screen.getByText("Creator")).toBeInTheDocument();
+    expect(screen.getByText("root")).toBeInTheDocument();
+    expect(screen.getByText("system")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-system")).toBeInTheDocument();
+  });
+
+  it("renders creator format with user kind", () => {
+    render(
+      <table><tbody><tr><MetaItem label="Creator" value="__CREATOR__john__user" /></tr></tbody></table>,
+    );
+    expect(screen.getByText("john")).toBeInTheDocument();
+    expect(screen.getByText("user")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-user")).toBeInTheDocument();
+  });
+
+  it("renders SQL-like value as pre element", () => {
+    const { container } = render(
+      <table><tbody><tr><MetaItem label="DDL" value="CREATE TABLE test (id INT)" /></tr></tbody></table>,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre).toBeInTheDocument();
+    expect(pre?.textContent).toBe("CREATE TABLE test (id INT)");
+  });
+});

--- a/frontend/src/utils/colors.test.ts
+++ b/frontend/src/utils/colors.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { C, ENTITY_BADGE } from "./colors";
+
+describe("C (color palette)", () => {
+  it("has all expected color keys", () => {
+    expect(C.bg).toBeDefined();
+    expect(C.card).toBeDefined();
+    expect(C.border).toBeDefined();
+    expect(C.borderLight).toBeDefined();
+    expect(C.text1).toBeDefined();
+    expect(C.text2).toBeDefined();
+    expect(C.text3).toBeDefined();
+    expect(C.accent).toBeDefined();
+    expect(C.green).toBeDefined();
+    expect(C.warning).toBeDefined();
+  });
+
+  it("all values are hex color strings", () => {
+    for (const value of Object.values(C)) {
+      expect(value).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+});
+
+describe("ENTITY_BADGE", () => {
+  it("has user badge colors", () => {
+    expect(ENTITY_BADGE.user.bg).toBeDefined();
+    expect(ENTITY_BADGE.user.fg).toBeDefined();
+  });
+
+  it("has role badge colors", () => {
+    expect(ENTITY_BADGE.role.bg).toBeDefined();
+    expect(ENTITY_BADGE.role.fg).toBeDefined();
+  });
+});

--- a/frontend/src/utils/scopeConfig.test.ts
+++ b/frontend/src/utils/scopeConfig.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { SCOPE_ORDER, SCOPE_ICONS } from "./scopeConfig";
+
+describe("SCOPE_ORDER", () => {
+  it("is an array of scope strings", () => {
+    expect(Array.isArray(SCOPE_ORDER)).toBe(true);
+    expect(SCOPE_ORDER.length).toBeGreaterThan(0);
+  });
+
+  it("starts with SYSTEM", () => {
+    expect(SCOPE_ORDER[0]).toBe("SYSTEM");
+  });
+
+  it("contains common scope types", () => {
+    expect(SCOPE_ORDER).toContain("CATALOG");
+    expect(SCOPE_ORDER).toContain("DATABASE");
+    expect(SCOPE_ORDER).toContain("TABLE");
+    expect(SCOPE_ORDER).toContain("VIEW");
+    expect(SCOPE_ORDER).toContain("FUNCTION");
+  });
+
+  it("has SYSTEM before CATALOG before DATABASE", () => {
+    const sysIdx = SCOPE_ORDER.indexOf("SYSTEM");
+    const catIdx = SCOPE_ORDER.indexOf("CATALOG");
+    const dbIdx = SCOPE_ORDER.indexOf("DATABASE");
+    expect(sysIdx).toBeLessThan(catIdx);
+    expect(catIdx).toBeLessThan(dbIdx);
+  });
+});
+
+describe("SCOPE_ICONS", () => {
+  it("maps common scopes to icon types", () => {
+    expect(SCOPE_ICONS.SYSTEM).toBe("system");
+    expect(SCOPE_ICONS.CATALOG).toBe("catalog");
+    expect(SCOPE_ICONS.DATABASE).toBe("database");
+    expect(SCOPE_ICONS.TABLE).toBe("table");
+    expect(SCOPE_ICONS.VIEW).toBe("view");
+    expect(SCOPE_ICONS["MATERIALIZED VIEW"]).toBe("mv");
+    expect(SCOPE_ICONS.FUNCTION).toBe("function");
+  });
+});

--- a/frontend/src/utils/toast.test.ts
+++ b/frontend/src/utils/toast.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("showToast", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Clean up any existing toast container from prior tests
+    const existing = document.getElementById("toast-container");
+    if (existing) existing.remove();
+    // Reset module state so `container` is re-created
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    const existing = document.getElementById("toast-container");
+    if (existing) existing.remove();
+  });
+
+  async function loadShowToast() {
+    const mod = await import("./toast");
+    return mod.showToast;
+  }
+
+  it("creates a toast container in document.body", async () => {
+    const showToast = await loadShowToast();
+    showToast("Test message");
+    const container = document.getElementById("toast-container");
+    expect(container).not.toBeNull();
+    expect(container?.parentElement).toBe(document.body);
+  });
+
+  it("creates a toast element with the message text", async () => {
+    const showToast = await loadShowToast();
+    showToast("Hello World");
+    const container = document.getElementById("toast-container");
+    expect(container).not.toBeNull();
+    const toast = container!.firstElementChild as HTMLDivElement;
+    expect(toast).not.toBeNull();
+    expect(toast.textContent).toBe("Hello World");
+  });
+
+  it("uses error styling by default", async () => {
+    const showToast = await loadShowToast();
+    showToast("Error occurred");
+    const container = document.getElementById("toast-container");
+    expect(container).not.toBeNull();
+    const toast = container!.firstElementChild as HTMLDivElement;
+    // jsdom converts hex to rgb
+    expect(toast.style.background).toBe("rgb(30, 18, 21)");
+    expect(toast.style.color).toBe("rgb(252, 165, 165)");
+  });
+
+  it("uses warning styling for warning type", async () => {
+    const showToast = await loadShowToast();
+    showToast("Warning message", "warning");
+    const container = document.getElementById("toast-container");
+    expect(container).not.toBeNull();
+    const toast = container!.firstElementChild as HTMLDivElement;
+    expect(toast.style.background).toBe("rgb(30, 26, 18)");
+    expect(toast.style.color).toBe("rgb(253, 230, 138)");
+  });
+
+  it("uses info styling for info type", async () => {
+    const showToast = await loadShowToast();
+    showToast("Info message", "info");
+    const container = document.getElementById("toast-container");
+    expect(container).not.toBeNull();
+    const toast = container!.firstElementChild as HTMLDivElement;
+    expect(toast.style.background).toBe("rgb(18, 26, 46)");
+    expect(toast.style.color).toBe("rgb(147, 197, 253)");
+  });
+
+  it("deduplicates: same message+type does not create duplicate", async () => {
+    const showToast = await loadShowToast();
+    showToast("Duplicate msg", "error");
+    showToast("Duplicate msg", "error");
+    const container = document.getElementById("toast-container");
+    expect(container).not.toBeNull();
+    expect(container!.children.length).toBe(1);
+  });
+
+  it("allows same message with different types", async () => {
+    const showToast = await loadShowToast();
+    showToast("Same msg", "error");
+    showToast("Same msg", "warning");
+    const container = document.getElementById("toast-container");
+    expect(container).not.toBeNull();
+    expect(container!.children.length).toBe(2);
+  });
+
+  it("auto-dismisses after duration", async () => {
+    const showToast = await loadShowToast();
+    showToast("Auto dismiss", "error", 3000);
+    const container = document.getElementById("toast-container");
+    expect(container).not.toBeNull();
+    expect(container!.children.length).toBe(1);
+
+    // Advance past the dismiss timeout
+    vi.advanceTimersByTime(3000);
+    // The dismiss function sets opacity and schedules removal after 200ms
+    vi.advanceTimersByTime(200);
+    expect(container!.children.length).toBe(0);
+  });
+
+  it("reuses existing container on multiple calls", async () => {
+    const showToast = await loadShowToast();
+    showToast("First", "error");
+    showToast("Second", "warning");
+    const containers = document.querySelectorAll("#toast-container");
+    expect(containers.length).toBe(1);
+  });
+
+  it("allows creating same toast after previous is dismissed", async () => {
+    const showToast = await loadShowToast();
+    showToast("Temp msg", "error", 1000);
+    const container = document.getElementById("toast-container");
+    expect(container).not.toBeNull();
+
+    // Dismiss the first one
+    vi.advanceTimersByTime(1000);
+    vi.advanceTimersByTime(200);
+    expect(container!.children.length).toBe(0);
+
+    // Now we should be able to create same toast again
+    showToast("Temp msg", "error", 1000);
+    expect(container!.children.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Improve test coverage from 35.52% to ~68.5% by adding 254 new tests across backend and frontend, targeting core service logic at 80%+ and overall 60-70%.

## Coverage Results

| Area | Before | After | Tests |
|------|--------|-------|-------|
| Backend | 55% | **82%** | 151 |
| Frontend | 8.57% | **44.36%** | 267 |
| **Combined** | **35.52%** | **~68.5%** | **418** |

### Backend Core Services (target 80%+)

| Module | Before | After |
|--------|--------|-------|
| grant_parser.py | 25% | **97%** |
| bfs_resolver.py | 46% | **97%** |
| show_grants_collector.py | 42% | **98%** |
| grant_resolver.py | 53% | **90%** |
| grant_classifier.py | 58% | **78%** |
| user_permissions.py | 6% | **78%** |
| user_roles.py | 18% | **83%** |
| user_search.py | 15% | **81%** |

## New Test Files (29)

**Backend (10 files, 81 tests):**
- `test_grant_classifier.py` — classify_grant() edge cases
- `test_grant_parser.py` — GRANT statement parsing (regex, multi-word types, paths)
- `test_bfs_resolver.py` — BFS traversal (chains, diamonds, cycles)
- `test_show_grants_collector.py` — non-admin grant collection + public probing
- `test_grant_resolver.py` — GrantResolver for_user/for_role/for_object
- `test_user_permissions.py` — GET /api/user/my-permissions (biggest gap: 6% → 78%)
- `test_user_roles_routes.py` — GET /api/user/roles/*
- `test_user_search_routes.py` — GET /api/user/search
- `test_admin_dag_routes.py` — GET /api/admin/dag/*
- `test_starrocks_client.py` — execute_query, execute_single, parallel_queries

**Frontend (19 files, 173 tests):**
- `client.test.ts` — apiFetch token injection, error handling, session expiry
- `LoginForm.test.tsx` — login flow, error display, loading state
- `PermissionMatrix.test.tsx` — GranteeName parsing, D/I indicators
- `GrantTreeView.test.tsx`, `Header.test.tsx`, `inventory-ui.test.tsx`
- `dagLayout.test.ts` (0% → 99%), `nodeIcons.test.ts`, `CustomNode.test.tsx`, `GroupNode.test.tsx`
- `toast.test.ts`, `colors.test.ts`, `scopeConfig.test.ts`
- `admin.test.ts`, `user.test.ts`, `auth.test.ts`
- `ExportPngBtn.test.tsx`, `InlineIcon.test.tsx`, `GroupDetailPanel.test.tsx`

## Duplication Avoidance

- Backend endpoint tests target `/api/user/*` routes (untested), not `/api/admin/*` (already covered)
- Core service unit tests cover edge cases unreachable via endpoint tests (cycles, non-admin paths)
- Frontend skips large components (InventoryTab, Sidebar) — deferred to E2E (#29)

## Test plan

- [x] Backend: 151 tests passing (`pytest`)
- [x] Frontend: 267 tests passing (`vitest`)
- [x] Backend coverage: 82%
- [x] Frontend coverage: 44.36%

🤖 Generated with [Claude Code](https://claude.com/claude-code)