### PR TITLE
Feature: cluster status drawer with FE /metrics and permission hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,8 @@ When code or project structure changes, run a sub-agent after completing the tas
 │   │   │   ├── admin_privileges.py  # GET /api/admin/privileges/* (Layer 1+2, admin only)
 │   │   │   ├── admin_roles.py       # GET /api/admin/roles/* (Layer 1+2, admin only)
 │   │   │   ├── admin_dag.py         # GET /api/admin/dag/* (Layer 1+2, admin only)
-│   │   │   └── admin_search.py      # GET /api/admin/search/* (Layer 1+2, admin only)
+│   │   │   ├── admin_search.py      # GET /api/admin/search/* (Layer 1+2, admin only)
+│   │   │   └── cluster.py           # GET /api/cluster/status (no require_admin; SR enforces cluster_admin)
 │   │   ├── services/
 │   │   │   ├── starrocks_client.py        # MySQL connector wrapper + parallel_queries
 │   │   │   ├── grant_collector.py         # Facade: delegates to common or admin collector
@@ -89,17 +90,22 @@ When code or project structure changes, run a sub-agent after completing the tas
         │   ├── client.ts            # Axios instance + interceptors
         │   ├── auth.ts              # Auth API
         │   ├── user.ts              # /api/user/* endpoints (all users)
-        │   └── admin.ts             # /api/admin/* endpoints (admin only)
-        ├── stores/              # Zustand (authStore, dagStore)
+        │   ├── admin.ts             # /api/admin/* endpoints (admin only)
+        │   └── cluster.ts           # /api/cluster/* (new category, separate from user/admin)
+        ├── stores/              # Zustand (authStore, dagStore, clusterStore)
+        │   └── clusterStore.ts      # Drawer open state + expanded nodes
         ├── utils/
         │   ├── grantDisplay.ts      # buildGrantDisplay() — unified grant grouping + implicit USAGE
         │   ├── inventory-helpers.ts  # SubTab/AllTab types, SUB_TAB_META, formatSQL/Bytes
         │   ├── privColors.ts        # Privilege tag color map
+        │   ├── relativeTime.ts      # formatRelativeTime helper
         │   ├── scopeConfig.ts       # SCOPE_ORDER, SCOPE_ICONS
         │   └── toast.ts             # Deduplicating toast
         └── components/
             ├── auth/LoginForm.tsx
-            ├── layout/Header.tsx, Sidebar.tsx  # Sidebar uses isAdmin-conditional APIs
+            ├── cluster/
+            │   └── ClusterDrawer.tsx  # Right-side drawer for FE/BE node health (440px)
+            ├── layout/Header.tsx, Sidebar.tsx  # Sidebar uses isAdmin-conditional APIs; Header has cluster icon
             ├── common/
             │   ├── InlineIcon.tsx     # SVG icon renderer
             │   ├── GrantTreeView.tsx  # Unified privilege display (scope-grouped)
@@ -176,8 +182,11 @@ When code or project structure changes, run a sub-agent after completing the tas
 - **Frontend API Pattern**: ← NEW
   - `api/user.ts`: Calls `/api/user/*` endpoints (all users)
   - `api/admin.ts`: Calls `/api/admin/*` endpoints (admin only)
+  - `api/cluster.ts`: Calls `/api/cluster/*` endpoints (new category, all logged-in users)
   - Each tab selects the appropriate API module based on `isAdmin` flag
   - Response schemas remain identical (`DAGGraph`, `PrivilegeGrant`, etc.) — only scope differs
+
+- **Cluster Status**: `/api/cluster/*` is a third route category (neither user nor admin). StarRocks enforces `cluster_admin` / SYSTEM OPERATE privilege for `SHOW FRONTENDS` / `SHOW BACKENDS`; backend catches mysql-connector `ProgrammingError`/`DatabaseError` with errno in {1044, 1045, 1227, 1142} and returns HTTP 403. TTL cache is per-username. UI: header cluster icon → right-side slide-out drawer (no new tab). Non-privileged users see an in-drawer permission-required message instead of data.
 
 - **DAG**: 2 views (Object Hierarchy TB, Role Hierarchy TB). `SET ROLE ALL` before object-hierarchy queries. (unchanged)
 
@@ -197,6 +206,7 @@ When code or project structure changes, run a sub-agent after completing the tas
 - /api/admin/* routes may call Layer 1 + Layer 2 services
 - /api/admin/* routes must verify is_admin via middleware
 - /api/auth/* routes are shared (no layer restriction)
+- /api/cluster/* is a new route category — no require_admin; StarRocks enforces privilege, backend maps access-denied errors to 403
 
 ### Code Quality
 - No duplicate grant parsing logic — use services/shared/grant_parser.py
@@ -286,4 +296,7 @@ python -m pytest tests/test_integration.py -v -s               # Integration (ne
 - Roles: GET /api/admin/roles, hierarchy, inheritance-dag, {name}/users
 - DAG: GET /api/admin/dag/object-hierarchy, role-hierarchy, full
 - Search: GET /api/admin/search, /api/admin/search/users-roles
+
+### Cluster Routes (`/api/cluster/*` — any logged-in user; StarRocks enforces privilege, 403 on denied)
+- Status: GET /api/cluster/status — FE/BE node list + aggregate metrics + has_errors flag
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ When code or project structure changes, run a sub-agent after completing the tas
 │   │       ├── session_store.py # In-memory server-side session store (includes is_admin)
 │   │       ├── sql_safety.py  # SQL injection protection (safe_name, safe_identifier)
 │   │       ├── cache.py       # Central cache clearing utility
-│   │       ├── sys_access.py  # can_access_sys() — checks sys.role_edges access
+│   │       ├── sys_access.py  # can_access_sys() — verifies full admin capability (see "Admin Detection" below)
 │   │       └── role_helpers.py # Shared: get_user_roles, get_parent_roles, parse_role_assignments
 │   └── tests/
 │       ├── conftest.py           # FakeConnection mock + fixtures
@@ -136,6 +136,22 @@ When code or project structure changes, run a sub-agent after completing the tas
 ## Key Design Decisions
 
 - **Auth**: StarRocks credentials → server-side session + JWT token. `is_admin` determined at login via `can_access_sys()` and stored in session.
+
+- **Admin Detection (`can_access_sys()`)**: To be flagged as admin, the user's StarRocks account (with `SET ROLE ALL` applied) must be able to execute **all** of the following:
+  1. `SELECT 1 FROM sys.role_edges LIMIT 1`
+  2. `SELECT 1 FROM sys.grants_to_users LIMIT 1`
+  3. `SELECT 1 FROM sys.grants_to_roles LIMIT 1`
+  4. `SHOW ROLES`  ← requires `user_admin` or `security_admin`
+
+  **Rationale**: Admin routes (`/api/admin/*`) call `SHOW ROLES`, `SHOW GRANTS FOR <user>`, and query all three sys.* tables. Granting a user SELECT on just `sys.role_edges` is not enough to drive the admin UI — the user would see the Permission Focus tab but every API call would fail. The detector verifies the user can actually run what the routes will run.
+
+  **Behavioral change from earlier versions**: Previously only `sys.role_edges` was checked. Users who had SELECT on that one table (without `user_admin`) were classified as admin but got 500 errors from admin routes. The stricter check keeps the UI and backend capabilities in sync.
+
+  **Implication**: A user with **only `cluster_admin`** (no `user_admin`/`security_admin`) is **not** admin in this app — they get the common UI plus the cluster drawer, not the Permission Focus tab. Grant `user_admin` (or `security_admin`) in addition to `cluster_admin` to enable the full admin UI.
+
+- **Connection-level Role Activation**: `get_db()` runs `SET ROLE ALL` on every new connection (wrapped in try/except — failures are non-fatal). Without this, users whose needed role is not their default role would get access-denied on sys.* queries even when granted.
+
+- **Database Error Mapping**: `main.py` registers a global `mysql.connector.errors.Error` handler that maps errno in `{1044, 1045, 1142, 1227}` (from `app.utils.sys_access.ACCESS_DENIED_ERRNOS`) to HTTP 403 with a human-readable message. All other DB errors return 500. This prevents access-denied errors from leaking as opaque 500s.
 
 - **3-Tier Data Access Architecture**: ← CHANGED (replaces previous "Admin vs Non-Admin")
   - **Common Tier**: `services/common/` — Uses only `INFORMATION_SCHEMA` and `SHOW` commands. StarRocks performs per-user permission filtering automatically, so no additional backend filtering is required. Used by all users, including admins.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A web UI for visually exploring user, role, and object permission structures acr
   - **Permission Focus**: Search a user or role → view inheritance DAG + privilege list (admin only)
   - **My Inventory**: Browse all accessible objects by type with detail side panel (Roles, Users, Catalogs, Databases, Tables, MVs, Views, Functions, Resource Groups, Warehouses, etc.)
 - **Admin & Non-Admin Support** — Admin users see all roles/users/objects via `/api/admin/*` routes (sys.* tables). Non-admin users see only their accessible objects and role chain via `/api/user/*` routes (SHOW GRANTS + INFORMATION_SCHEMA). Admin routes enforce `require_admin` (403 for non-admin).
+- **Cluster Status** — Header cluster icon opens a right-side drawer showing FE/BE node health and aggregate metrics. Visible to all logged-in users; requires `cluster_admin` role or SYSTEM OPERATE privilege in StarRocks (non-privileged users see an in-drawer message).
 - **Object Permission Matrix** — Click an object to see a grantee × privilege matrix (Direct/Inherited indicators), with type-specific columns per object type
 - **Implicit USAGE** — TABLE-level grants automatically show implicit DATABASE/CATALOG USAGE access
 - **User/Role Privilege View** — Unified scope-grouped tree (GrantTreeView) across all panels

--- a/README.md
+++ b/README.md
@@ -147,11 +147,34 @@ Features: text filter, A→Z/Z→A column sorting, pagination (10/25/50/100 per 
 | Feature | Admin (sys.* accessible) | Non-Admin (SHOW GRANTS only) |
 |---------|-------------------------|------------------------------|
 | Object Hierarchy | All objects in cluster | Only accessible objects (SET ROLE ALL) |
-| Role Map | All roles + all users | Own role chain only |
+| Role Map | All roles + all users | Own role chain only (includes implicit `public`) |
 | Permission Focus | Available | Hidden |
 | My Inventory | All roles, all users | Own roles/objects only |
 | Permission Matrix | All grantees shown | Own role chain grantees |
 | Implicit USAGE | Shown on DB/Catalog | Shown on DB/Catalog |
+| Cluster Status drawer | Full FE/BE/CN inventory | Single FE (the one you're connected to) — `mode="limited"` |
+
+#### Admin Detection — what "admin" means in this app
+
+At login the backend runs `SET ROLE ALL` and then checks that your StarRocks account can execute **every** query the admin routes rely on:
+
+1. `SELECT 1 FROM sys.role_edges LIMIT 1`
+2. `SELECT 1 FROM sys.grants_to_users LIMIT 1`
+3. `SELECT 1 FROM sys.grants_to_roles LIMIT 1`
+4. `SHOW ROLES`
+
+If **any** of these fails, you are treated as a non-admin. The simplest way to satisfy all four is to grant either of the built-in roles **`user_admin`** or **`security_admin`** — both give `SELECT` on all three `sys.*` tables *and* the ability to run `SHOW ROLES`.
+
+```sql
+-- Typical admin setup
+GRANT user_admin TO <username>;
+-- or for read-only admins:
+GRANT security_admin TO <username>;
+```
+
+> **Note**: `cluster_admin` alone is **not** enough — it governs `SHOW FRONTENDS` / `SHOW BACKENDS` (used by the cluster drawer) but does not grant the privileges required by the Permission Focus tab or admin-scoped DAG views. If a user has only `cluster_admin`, they see the common UI plus the full cluster drawer, but not the admin tabs.
+
+If you have admin-level roles but they aren't your default role, the app runs `SET ROLE ALL` for you — no need to `SET DEFAULT ROLE ALL` manually.
 
 ### Detail Panels
 

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import logging
+
 from fastapi import Depends, Header, HTTPException
 
-from app.services.starrocks_client import get_connection
+from app.services.starrocks_client import execute_query, get_connection
 from app.utils.session import decode_token
 from app.utils.session_store import session_store
+
+logger = logging.getLogger(__name__)
 
 
 def get_credentials(authorization: str = Header(...)) -> dict:
@@ -41,4 +45,8 @@ def get_db(credentials: dict = Depends(get_credentials)):
         username=credentials["username"],
         password=credentials["password"],
     ) as conn:
+        try:
+            execute_query(conn, "SET ROLE ALL")
+        except Exception:
+            logger.debug("SET ROLE ALL failed on new connection — proceeding with default role")
         yield conn

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,7 +23,7 @@ from app.routers import (
     user_search,
 )
 from app.utils.session_store import session_store
-from app.utils.sys_access import ACCESS_DENIED_ERRNOS
+from app.utils.sys_access import is_access_denied
 
 logger = logging.getLogger(__name__)
 
@@ -74,8 +74,7 @@ app.include_router(cluster.router, prefix="/api/cluster", tags=["cluster"])
 
 @app.exception_handler(mysql.connector.errors.Error)
 async def mysql_error_handler(request: Request, exc: mysql.connector.errors.Error):
-    errno = getattr(exc, "errno", None)
-    if errno in ACCESS_DENIED_ERRNOS:
+    if is_access_denied(exc):
         logger.warning("DB access denied for %s: %s", request.url.path, exc)
         return JSONResponse(
             status_code=403,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,16 +1,20 @@
 import asyncio
+import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+import mysql.connector.errors
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from app.config import settings
-from app.routers import auth
 from app.routers import (
     admin_dag,
     admin_privileges,
     admin_roles,
     admin_search,
+    auth,
+    cluster,
     user_dag,
     user_objects,
     user_permissions,
@@ -19,6 +23,9 @@ from app.routers import (
     user_search,
 )
 from app.utils.session_store import session_store
+from app.utils.sys_access import ACCESS_DENIED_ERRNOS
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -60,6 +67,22 @@ app.include_router(admin_privileges.router, prefix="/api/admin/privileges", tags
 app.include_router(admin_roles.router, prefix="/api/admin/roles", tags=["admin-roles"])
 app.include_router(admin_dag.router, prefix="/api/admin/dag", tags=["admin-dag"])
 app.include_router(admin_search.router, prefix="/api/admin/search", tags=["admin-search"])
+
+# Cluster routes (all logged-in users; StarRocks enforces cluster_admin / SYSTEM OPERATE)
+app.include_router(cluster.router, prefix="/api/cluster", tags=["cluster"])
+
+
+@app.exception_handler(mysql.connector.errors.Error)
+async def mysql_error_handler(request: Request, exc: mysql.connector.errors.Error):
+    errno = getattr(exc, "errno", None)
+    if errno in ACCESS_DENIED_ERRNOS:
+        logger.warning("DB access denied for %s: %s", request.url.path, exc)
+        return JSONResponse(
+            status_code=403,
+            content={"detail": "Insufficient database privileges. Try re-logging in or contact your admin."},
+        )
+    logger.error("Unexpected DB error for %s: %s", request.url.path, exc)
+    return JSONResponse(status_code=500, content={"detail": "Database error"})
 
 
 @app.get("/api/health")

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -122,3 +122,78 @@ class TableDetail(BaseModel):
     replication_num: int | None = None
     storage_medium: str | None = None
     compression: str | None = None
+
+
+# ── Cluster Status ──
+class FENodeInfo(BaseModel):
+    name: str
+    ip: str
+    edit_log_port: int | None = None
+    http_port: int | None = None
+    query_port: int | None = None
+    rpc_port: int | None = None
+    role: str
+    alive: bool
+    join: bool
+    last_heartbeat: str | None = None
+    replayed_journal_id: int | None = None
+    start_time: str | None = None
+    version: str | None = None
+    err_msg: str | None = None
+    # Populated from FE /metrics endpoint (unauthenticated Prometheus scrape)
+    jvm_heap_used_pct: float | None = None
+    gc_young_count: int | None = None
+    gc_young_time_ms: int | None = None
+    gc_old_count: int | None = None
+    gc_old_time_ms: int | None = None
+    query_p99_ms: float | None = None
+    metrics_error: str | None = None  # null on success; short reason string on failure
+
+
+class BENodeInfo(BaseModel):
+    name: str
+    ip: str
+    node_type: str = "backend"  # "backend" (SHOW BACKENDS) or "compute" (SHOW COMPUTE NODES)
+    heartbeat_port: int | None = None
+    be_port: int | None = None
+    http_port: int | None = None
+    brpc_port: int | None = None
+    alive: bool
+    last_heartbeat: str | None = None
+    last_start_time: str | None = None
+    tablet_count: int | None = None
+    data_used_capacity: str | None = None
+    total_capacity: str | None = None
+    used_pct: float | None = None
+    cpu_cores: int | None = None
+    cpu_used_pct: float | None = None  # Only populated for compute nodes (SHOW COMPUTE NODES)
+    mem_used_pct: float | None = None
+    mem_limit: str | None = None  # Human-readable total memory (e.g. "75.687GB"); CN only
+    num_running_queries: int | None = None
+    warehouse: str | None = None  # Only populated for compute nodes
+    version: str | None = None
+    err_msg: str | None = None
+
+
+class ClusterMetrics(BaseModel):
+    fe_total: int
+    fe_alive: int
+    be_total: int
+    be_alive: int
+    cn_total: int = 0
+    cn_alive: int = 0
+    total_tablets: int | None = None
+    total_data_used: str | None = None
+    avg_disk_used_pct: float | None = None
+    avg_cpu_used_pct: float | None = None
+    avg_mem_used_pct: float | None = None
+    avg_fe_heap_used_pct: float | None = None  # from FE /metrics
+
+
+class ClusterStatusResponse(BaseModel):
+    frontends: list[FENodeInfo]
+    backends: list[BENodeInfo]
+    metrics: ClusterMetrics
+    has_errors: bool
+    mode: str = "full"  # "full" = SHOW succeeded; "limited" = access-denied fallback
+    metrics_warning: str | None = None  # set iff all FE /metrics fetches failed

--- a/backend/app/routers/cluster.py
+++ b/backend/app/routers/cluster.py
@@ -34,7 +34,7 @@ from app.models.schemas import (
 )
 from app.services.fe_metrics import FEMetricsData, FEMetricsError, fetch_fe_metrics
 from app.services.starrocks_client import execute_query
-from app.utils.sys_access import ACCESS_DENIED_ERRNOS
+from app.utils.sys_access import is_access_denied
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -68,7 +68,7 @@ def _parse_float(val) -> float | None:
     if val is None:
         return None
     try:
-        return float(str(val).strip().rstrip(" %").rstrip("%").strip())
+        return float(str(val).strip().rstrip("% "))
     except (ValueError, TypeError):
         return None
 
@@ -289,15 +289,6 @@ def _compute_metrics(
     )
 
 
-def _is_access_denied(exc: Exception) -> bool:
-    errno = getattr(exc, "errno", None)
-    if errno in ACCESS_DENIED_ERRNOS:
-        return True
-    # Fallback substring check — StarRocks sometimes returns access-denied as ProgrammingError
-    # without a standard MySQL errno; match its canonical prefix only.
-    return "Access denied" in str(exc)
-
-
 _DEFAULT_FE_HTTP_PORT = 8030
 _METRICS_TIMEOUT_SECONDS = 2.0
 
@@ -399,7 +390,7 @@ def get_cluster_status(
     try:
         fe_rows = execute_query(conn, "SHOW FRONTENDS")
     except (mysql.connector.errors.ProgrammingError, mysql.connector.errors.DatabaseError) as exc:
-        if _is_access_denied(exc):
+        if is_access_denied(exc):
             mode = "limited"
             logger.debug("SHOW FRONTENDS denied for %s → limited mode", username)
         else:
@@ -410,7 +401,7 @@ def get_cluster_status(
         try:
             be_rows = execute_query(conn, "SHOW BACKENDS")
         except (mysql.connector.errors.ProgrammingError, mysql.connector.errors.DatabaseError) as exc:
-            if _is_access_denied(exc):
+            if is_access_denied(exc):
                 mode = "limited"
                 be_rows = []
                 logger.debug("SHOW BACKENDS denied — downgrading to limited mode")
@@ -421,7 +412,7 @@ def get_cluster_status(
         try:
             cn_rows = execute_query(conn, "SHOW COMPUTE NODES")
         except (mysql.connector.errors.ProgrammingError, mysql.connector.errors.DatabaseError) as exc:
-            if _is_access_denied(exc):
+            if is_access_denied(exc):
                 # CN privilege doesn't exist separately in practice; downgrade too.
                 mode = "limited"
                 be_rows = []

--- a/backend/app/routers/cluster.py
+++ b/backend/app/routers/cluster.py
@@ -1,0 +1,464 @@
+"""Router for /api/cluster/status endpoint.
+
+Common UI — any logged-in user can reach it.
+
+* When SHOW FRONTENDS/BACKENDS/COMPUTE NODES succeed (user has cluster_admin),
+  the response includes the full node inventory (`mode="full"`).
+* When SHOW FRONTENDS is denied by StarRocks, the endpoint falls back to
+  `mode="limited"`: a single FENodeInfo representing the FE the user is
+  connected to, with resource metrics populated from the unauthenticated
+  `/metrics` endpoint.
+* Each FE's /metrics is probed in parallel (ThreadPoolExecutor, 2s timeout).
+  Individual failures populate `metrics_error` on that FENodeInfo. If every
+  FE probe fails, `metrics_warning` is set so the UI can show a banner.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import mysql.connector.errors
+from cachetools import TTLCache
+from fastapi import APIRouter, Depends
+
+from app.config import settings
+from app.dependencies import get_credentials, get_db
+from app.models.schemas import (
+    BENodeInfo,
+    ClusterMetrics,
+    ClusterStatusResponse,
+    FENodeInfo,
+)
+from app.services.fe_metrics import FEMetricsData, FEMetricsError, fetch_fe_metrics
+from app.services.starrocks_client import execute_query
+from app.utils.sys_access import ACCESS_DENIED_ERRNOS
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# ── TTL cache (per username) ──
+_cluster_cache: TTLCache = TTLCache(maxsize=8, ttl=settings.cache_ttl_seconds)
+_cluster_cache_lock = threading.Lock()
+
+
+# ── Parse helpers ──
+
+
+def _parse_bool(val) -> bool:
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.strip().upper() == "TRUE"
+    return bool(val)
+
+
+def _parse_int(val) -> int | None:
+    if val is None:
+        return None
+    try:
+        return int(str(val).strip())
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_float(val) -> float | None:
+    if val is None:
+        return None
+    try:
+        return float(str(val).strip().rstrip(" %").rstrip("%").strip())
+    except (ValueError, TypeError):
+        return None
+
+
+# ── Human-readable size helpers ──
+
+_SIZE_UNITS = {
+    "b": 1,
+    "kb": 1024,
+    "mb": 1024**2,
+    "gb": 1024**3,
+    "tb": 1024**4,
+    "pb": 1024**5,
+}
+
+
+def _parse_size_bytes(s: str) -> float:
+    """Convert a size string like '256.78 GB' to bytes (float)."""
+    s = s.strip()
+    for unit, factor in sorted(_SIZE_UNITS.items(), key=lambda x: -x[1]):
+        if s.lower().endswith(unit):
+            try:
+                return float(s[: -len(unit)].strip()) * factor
+            except ValueError:
+                return 0.0
+    # Assume bytes if no unit
+    try:
+        return float(s)
+    except ValueError:
+        return 0.0
+
+
+def _bytes_to_human(total_bytes: float) -> str:
+    """Convert bytes to a human-readable string (up to PB)."""
+    for unit in ("PB", "TB", "GB", "MB", "KB"):
+        divisor = _SIZE_UNITS[unit.lower()]
+        if total_bytes >= divisor:
+            return f"{total_bytes / divisor:.2f} {unit}"
+    return f"{int(total_bytes)} B"
+
+
+def _human_size_sum(sizes: list[str]) -> str | None:
+    """Sum a list of human-readable size strings and return a human-readable total."""
+    if not sizes:
+        return None
+    total = sum(_parse_size_bytes(s) for s in sizes)
+    return _bytes_to_human(total)
+
+
+# DataCacheMetrics from SHOW COMPUTE NODES, e.g.:
+#   "Status: Normal, DiskUsage: 79MB/10GB, MemUsage: 35.2MB/15.1GB"
+_DATACACHE_DISK_RE = re.compile(r"DiskUsage:\s*([\d.]+\s*[KMGTP]?B)\s*/\s*([\d.]+\s*[KMGTP]?B)", re.IGNORECASE)
+
+
+def _parse_datacache_disk(raw: str | None) -> tuple[str | None, str | None, float | None]:
+    """Parse DataCacheMetrics string → (used, total, used_pct). All None on failure."""
+    if not raw:
+        return None, None, None
+    m = _DATACACHE_DISK_RE.search(raw)
+    if not m:
+        return None, None, None
+    used_str, total_str = m.group(1).strip(), m.group(2).strip()
+    used_bytes = _parse_size_bytes(used_str)
+    total_bytes = _parse_size_bytes(total_str)
+    pct = round(used_bytes / total_bytes * 100, 2) if total_bytes > 0 else None
+    return used_str, total_str, pct
+
+
+# ── Row → model helpers ──
+
+
+def _fe_row_to_info(r: dict) -> FENodeInfo:
+    ip = r.get("IP") or r.get("Host") or ""
+    name = r.get("Name") or ip
+
+    # Role: IsMaster=true → LEADER, else use Role column or default FOLLOWER
+    is_master = _parse_bool(r.get("IsMaster", False))
+    if is_master:
+        role = "LEADER"
+    else:
+        role = r.get("Role") or "FOLLOWER"
+
+    alive = _parse_bool(r.get("Alive", False))
+    join = _parse_bool(r.get("Join", False))
+    err_msg = r.get("ErrMsg") or None
+
+    return FENodeInfo(
+        name=name,
+        ip=ip,
+        edit_log_port=_parse_int(r.get("EditLogPort")),
+        http_port=_parse_int(r.get("HttpPort")),
+        query_port=_parse_int(r.get("QueryPort")),
+        rpc_port=_parse_int(r.get("RpcPort")),
+        role=role,
+        alive=alive,
+        join=join,
+        last_heartbeat=r.get("LastHeartbeat") or None,
+        replayed_journal_id=_parse_int(r.get("ReplayedJournalId")),
+        start_time=r.get("StartTime") or None,
+        version=r.get("Version") or None,
+        err_msg=err_msg,
+    )
+
+
+def _be_row_to_info(r: dict) -> BENodeInfo:
+    ip = r.get("Host") or r.get("IP") or ""
+    name = r.get("BackendId") or r.get("Name") or ip
+    # Normalise name to string
+    name = str(name)
+
+    alive = _parse_bool(r.get("Alive", False))
+    err_msg = r.get("ErrMsg") or None
+
+    return BENodeInfo(
+        name=name,
+        ip=ip,
+        node_type="backend",
+        heartbeat_port=_parse_int(r.get("HeartbeatPort")),
+        be_port=_parse_int(r.get("BePort")),
+        http_port=_parse_int(r.get("HttpPort")),
+        brpc_port=_parse_int(r.get("BrpcPort")),
+        alive=alive,
+        last_heartbeat=r.get("LastHeartbeat") or None,
+        last_start_time=r.get("LastStartTime") or None,
+        tablet_count=_parse_int(r.get("TabletNum")),
+        data_used_capacity=r.get("DataUsedCapacity") or None,
+        total_capacity=r.get("TotalCapacity") or None,
+        used_pct=_parse_float(r.get("UsedPct")),
+        cpu_cores=_parse_int(r.get("CpuCores")),
+        mem_used_pct=_parse_float(r.get("MemUsedPct")),
+        num_running_queries=_parse_int(r.get("NumRunningQueries")),
+        version=r.get("Version") or None,
+        err_msg=err_msg,
+    )
+
+
+def _cn_row_to_info(r: dict) -> BENodeInfo:
+    """Convert SHOW COMPUTE NODES row to BENodeInfo with node_type='compute'.
+
+    Compute nodes have no persistent storage (disk_used/total/used_pct are None)
+    but do report CPU%, memory%, warehouse, and (cached) tablet count.
+    """
+    ip = r.get("IP") or r.get("Host") or ""
+    name = r.get("ComputeNodeId") or r.get("Name") or ip
+    name = str(name)
+
+    # Local data cache usage — CN has no persistent storage but caches hot data locally.
+    cache_used, cache_total, cache_pct = _parse_datacache_disk(r.get("DataCacheMetrics"))
+
+    return BENodeInfo(
+        name=name,
+        ip=ip,
+        node_type="compute",
+        heartbeat_port=_parse_int(r.get("HeartbeatPort")),
+        be_port=_parse_int(r.get("BePort")),
+        http_port=_parse_int(r.get("HttpPort")),
+        brpc_port=_parse_int(r.get("BrpcPort")),
+        alive=_parse_bool(r.get("Alive", False)),
+        last_heartbeat=r.get("LastHeartbeat") or None,
+        last_start_time=r.get("LastStartTime") or None,
+        tablet_count=_parse_int(r.get("TabletNum")),
+        # For CN these fields represent LOCAL DATA CACHE usage (not persistent storage).
+        # The UI labels them "Disk Cache" to distinguish from BE's persistent disk.
+        data_used_capacity=cache_used,
+        total_capacity=cache_total,
+        used_pct=cache_pct,
+        cpu_cores=_parse_int(r.get("CpuCores")),
+        cpu_used_pct=_parse_float(r.get("CpuUsedPct")),
+        mem_used_pct=_parse_float(r.get("MemUsedPct")),
+        mem_limit=r.get("MemLimit") or None,
+        num_running_queries=_parse_int(r.get("NumRunningQueries")),
+        warehouse=r.get("WarehouseName") or None,
+        version=r.get("Version") or None,
+        err_msg=r.get("ErrMsg") or None,
+    )
+
+
+def _compute_metrics(
+    frontends: list[FENodeInfo],
+    backends: list[BENodeInfo],
+) -> ClusterMetrics:
+    fe_alive = sum(1 for fe in frontends if fe.alive)
+    be_nodes = [b for b in backends if b.node_type == "backend"]
+    cn_nodes = [b for b in backends if b.node_type == "compute"]
+    be_alive = sum(1 for b in be_nodes if b.alive)
+    cn_alive = sum(1 for c in cn_nodes if c.alive)
+
+    tablet_counts = [b.tablet_count for b in backends if b.tablet_count is not None]
+    total_tablets = sum(tablet_counts) if tablet_counts else None
+
+    # Only BE nodes have persistent storage volumes.  CN "data_used_capacity"
+    # is actually its local data-cache usage, not persistent data — don't include.
+    size_strs = [b.data_used_capacity for b in be_nodes if b.data_used_capacity]
+    total_data_used = _human_size_sum(size_strs) if size_strs else None
+
+    # Disk usage % is averaged across all nodes that report one (BE disk OR CN cache).
+    # The frontend labels this "Avg Disk" or "Avg Cache" depending on the cluster shape.
+    disk_pcts = [b.used_pct for b in backends if b.used_pct is not None]
+    cpu_pcts = [b.cpu_used_pct for b in backends if b.cpu_used_pct is not None]
+    mem_pcts = [b.mem_used_pct for b in backends if b.mem_used_pct is not None]
+
+    avg_disk = round(sum(disk_pcts) / len(disk_pcts), 2) if disk_pcts else None
+    avg_cpu = round(sum(cpu_pcts) / len(cpu_pcts), 2) if cpu_pcts else None
+    avg_mem = round(sum(mem_pcts) / len(mem_pcts), 2) if mem_pcts else None
+
+    return ClusterMetrics(
+        fe_total=len(frontends),
+        fe_alive=fe_alive,
+        be_total=len(be_nodes),
+        be_alive=be_alive,
+        cn_total=len(cn_nodes),
+        cn_alive=cn_alive,
+        total_tablets=total_tablets,
+        total_data_used=total_data_used,
+        avg_disk_used_pct=avg_disk,
+        avg_cpu_used_pct=avg_cpu,
+        avg_mem_used_pct=avg_mem,
+    )
+
+
+def _is_access_denied(exc: Exception) -> bool:
+    errno = getattr(exc, "errno", None)
+    if errno in ACCESS_DENIED_ERRNOS:
+        return True
+    # Fallback substring check — StarRocks sometimes returns access-denied as ProgrammingError
+    # without a standard MySQL errno; match its canonical prefix only.
+    return "Access denied" in str(exc)
+
+
+_DEFAULT_FE_HTTP_PORT = 8030
+_METRICS_TIMEOUT_SECONDS = 2.0
+
+
+def _limited_mode_fe(host: str) -> FENodeInfo:
+    """Build a best-effort FENodeInfo for non-cluster_admin users.
+
+    Only fields we can know without SHOW FRONTENDS: host/port and a placeholder
+    role. Resource fields are filled in afterwards from /metrics.
+    """
+    return FENodeInfo(
+        name=host,
+        ip=host,
+        http_port=_DEFAULT_FE_HTTP_PORT,
+        role="UNKNOWN",
+        alive=True,  # assumed — we're connected to it via SQL
+        join=True,
+    )
+
+
+def _inject_metrics(frontends: list[FENodeInfo]) -> str | None:
+    """Probe each FE's /metrics in parallel and populate the matching fields.
+
+    Returns a metrics_warning string iff every FE probe failed (so the UI can
+    show a single aggregate banner). Per-node failures set `metrics_error`.
+    """
+    if not frontends:
+        return None
+
+    def _probe(fe: FENodeInfo) -> tuple[FENodeInfo, FEMetricsData | FEMetricsError]:
+        port = fe.http_port or _DEFAULT_FE_HTTP_PORT
+        return fe, fetch_fe_metrics(fe.ip, port, timeout=_METRICS_TIMEOUT_SECONDS)
+
+    any_success = False
+    with ThreadPoolExecutor(max_workers=min(3, len(frontends))) as pool:
+        for fe, result in pool.map(_probe, frontends):
+            if isinstance(result, FEMetricsData):
+                any_success = True
+                fe.jvm_heap_used_pct = result.heap_used_pct
+                fe.gc_young_count = result.gc_young_count
+                fe.gc_young_time_ms = result.gc_young_time_ms
+                fe.gc_old_count = result.gc_old_count
+                fe.gc_old_time_ms = result.gc_old_time_ms
+                fe.query_p99_ms = result.query_p99_ms
+            else:
+                fe.metrics_error = f"{result.reason}: {result.message}"
+
+    if not any_success:
+        return (
+            "Resource metrics unreachable (port "
+            f"{_DEFAULT_FE_HTTP_PORT} not accessible from the server). "
+            "Node list still available."
+        )
+    return None
+
+
+@router.get("/status", response_model=ClusterStatusResponse)
+def get_cluster_status(
+    conn=Depends(get_db),
+    credentials: dict = Depends(get_credentials),
+):
+    """Return FE/BE/CN inventory + resource metrics.
+
+    No require_admin guard — any logged-in user may call this. When StarRocks
+    denies SHOW FRONTENDS (no cluster_admin role), we fall back to a single-FE
+    "limited" view so basic cluster health is still visible (common UI).
+    """
+    username = credentials["username"]
+    host = credentials.get("host") or ""
+
+    # Cache key includes mode so that if a user's role assignments change mid-session
+    # the "full" and "limited" responses don't collide.
+    def _cached(mode: str) -> ClusterStatusResponse | None:
+        with _cluster_cache_lock:
+            return _cluster_cache.get(f"cluster_status_{username}:{mode}")
+
+    def _save(mode: str, resp: ClusterStatusResponse) -> None:
+        with _cluster_cache_lock:
+            _cluster_cache[f"cluster_status_{username}:{mode}"] = resp
+
+    # Fast path: serve either mode from cache if present.
+    for cached_mode in ("full", "limited"):
+        hit = _cached(cached_mode)
+        if hit is not None:
+            return hit
+
+    # Activate all granted roles so non-default roles like cluster_admin apply.
+    try:
+        execute_query(conn, "SET ROLE ALL")
+    except Exception:
+        logger.debug("Failed to SET ROLE ALL for user %s", username)
+
+    mode = "full"
+    fe_rows: list[dict] = []
+    be_rows: list[dict] = []
+    cn_rows: list[dict] = []
+
+    # SHOW FRONTENDS — the gate for full mode.
+    try:
+        fe_rows = execute_query(conn, "SHOW FRONTENDS")
+    except (mysql.connector.errors.ProgrammingError, mysql.connector.errors.DatabaseError) as exc:
+        if _is_access_denied(exc):
+            mode = "limited"
+            logger.debug("SHOW FRONTENDS denied for %s → limited mode", username)
+        else:
+            raise
+
+    # SHOW BACKENDS / COMPUTE NODES — only meaningful in full mode.
+    if mode == "full":
+        try:
+            be_rows = execute_query(conn, "SHOW BACKENDS")
+        except (mysql.connector.errors.ProgrammingError, mysql.connector.errors.DatabaseError) as exc:
+            if _is_access_denied(exc):
+                mode = "limited"
+                be_rows = []
+                logger.debug("SHOW BACKENDS denied — downgrading to limited mode")
+            else:
+                raise
+
+    if mode == "full":
+        try:
+            cn_rows = execute_query(conn, "SHOW COMPUTE NODES")
+        except (mysql.connector.errors.ProgrammingError, mysql.connector.errors.DatabaseError) as exc:
+            if _is_access_denied(exc):
+                # CN privilege doesn't exist separately in practice; downgrade too.
+                mode = "limited"
+                be_rows = []
+                cn_rows = []
+                logger.debug("SHOW COMPUTE NODES denied — downgrading to limited mode")
+            else:
+                logger.debug("SHOW COMPUTE NODES not available: %s", exc)
+
+    # Build node lists.
+    if mode == "full":
+        frontends = [_fe_row_to_info(r) for r in fe_rows]
+        backends = [_be_row_to_info(r) for r in be_rows] + [_cn_row_to_info(r) for r in cn_rows]
+    else:
+        frontends = [_limited_mode_fe(host or "localhost")]
+        backends = []
+
+    # Inject /metrics-derived resource fields.
+    metrics_warning = _inject_metrics(frontends)
+
+    # Compute aggregate metrics.
+    metrics = _compute_metrics(frontends, backends)
+    heap_pcts = [fe.jvm_heap_used_pct for fe in frontends if fe.jvm_heap_used_pct is not None]
+    if heap_pcts:
+        metrics.avg_fe_heap_used_pct = round(sum(heap_pcts) / len(heap_pcts), 2)
+
+    has_errors = any((not fe.alive) or bool(fe.err_msg) for fe in frontends) or any(
+        (not be.alive) or bool(be.err_msg) for be in backends
+    )
+
+    result = ClusterStatusResponse(
+        frontends=frontends,
+        backends=backends,
+        metrics=metrics,
+        has_errors=has_errors,
+        mode=mode,
+        metrics_warning=metrics_warning,
+    )
+
+    _save(mode, result)
+    return result

--- a/backend/app/routers/user_roles.py
+++ b/backend/app/routers/user_roles.py
@@ -158,6 +158,9 @@ def _build_role_hierarchy_from_grants(conn, username: str) -> DAGGraph:
 
     # BFS through role chain
     direct_roles = parse_role_assignments(conn, username, "USER")
+    # Every user implicitly has 'public' — SHOW GRANTS omits it but it should appear in the DAG
+    if "public" not in direct_roles:
+        direct_roles = [*direct_roles, "public"]
     for role in direct_roles:
         rc = "root" if role == "root" else "builtin" if role in BUILTIN_ROLES else "custom"
         add_node(f"r_{role}", role, "role", metadata={"role_category": rc})

--- a/backend/app/services/fe_metrics.py
+++ b/backend/app/services/fe_metrics.py
@@ -1,0 +1,114 @@
+"""Mini Prometheus text-format parser + HTTP fetcher for StarRocks FE /metrics.
+
+StarRocks FE exposes an unauthenticated Prometheus-compatible `/metrics` endpoint on
+the FE HTTP port (default 8030). We use it to augment cluster status with JVM heap,
+GC, and query p99 latency — information not available via SHOW FRONTENDS.
+
+Only a small, curated subset of metrics is parsed (intentionally shallow detail).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FEMetricsData:
+    heap_used_pct: float | None = None
+    gc_young_count: int | None = None
+    gc_young_time_ms: int | None = None
+    gc_old_count: int | None = None
+    gc_old_time_ms: int | None = None
+    query_p99_ms: float | None = None
+
+
+@dataclass
+class FEMetricsError:
+    reason: str  # "timeout" | "network" | "http_status" | "parse" | "unknown"
+    message: str
+
+
+# Regex patterns that extract the specific metric lines we need.
+# Prometheus text format: <metric_name>{labels} <value>
+_HEAP_USED_RE = re.compile(r'^jvm_heap_size_bytes\{type="used"\}\s+([\d.eE+-]+)', re.MULTILINE)
+_HEAP_MAX_RE = re.compile(r'^jvm_heap_size_bytes\{type="max"\}\s+([\d.eE+-]+)', re.MULTILINE)
+_GC_YOUNG_COUNT_RE = re.compile(r'^jvm_young_gc\{type="count"\}\s+(\d+)', re.MULTILINE)
+_GC_YOUNG_TIME_RE = re.compile(r'^jvm_young_gc\{type="time"\}\s+(\d+)', re.MULTILINE)
+_GC_OLD_COUNT_RE = re.compile(r'^jvm_old_gc\{type="count"\}\s+(\d+)', re.MULTILINE)
+_GC_OLD_TIME_RE = re.compile(r'^jvm_old_gc\{type="time"\}\s+(\d+)', re.MULTILINE)
+_P99_RE = re.compile(r'^starrocks_fe_query_latency\{type="99_quantile"\}\s+([\d.eE+-]+)', re.MULTILINE)
+
+
+def _extract_float(pattern: re.Pattern, body: str) -> float | None:
+    m = pattern.search(body)
+    if not m:
+        return None
+    try:
+        return float(m.group(1))
+    except (ValueError, TypeError):
+        return None
+
+
+def _extract_int(pattern: re.Pattern, body: str) -> int | None:
+    m = pattern.search(body)
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_metrics_body(body: str) -> FEMetricsData:
+    """Parse the targeted metric lines. Missing lines → that field stays None."""
+    heap_used = _extract_float(_HEAP_USED_RE, body)
+    heap_max = _extract_float(_HEAP_MAX_RE, body)
+    heap_pct: float | None = None
+    if heap_used is not None and heap_max is not None and heap_max > 0:
+        heap_pct = round(heap_used / heap_max * 100, 2)
+
+    return FEMetricsData(
+        heap_used_pct=heap_pct,
+        gc_young_count=_extract_int(_GC_YOUNG_COUNT_RE, body),
+        gc_young_time_ms=_extract_int(_GC_YOUNG_TIME_RE, body),
+        gc_old_count=_extract_int(_GC_OLD_COUNT_RE, body),
+        gc_old_time_ms=_extract_int(_GC_OLD_TIME_RE, body),
+        query_p99_ms=_extract_float(_P99_RE, body),
+    )
+
+
+def fetch_fe_metrics(
+    host: str,
+    http_port: int,
+    timeout: float = 2.0,
+) -> FEMetricsData | FEMetricsError:
+    """Fetch and parse FE /metrics. Returns FEMetricsError on any failure."""
+    url = f"http://{host}:{http_port}/metrics"
+    try:
+        req = urllib.request.Request(url, headers={"Accept": "text/plain"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310  (trusted internal URL)
+            status = resp.status
+            if status != 200:
+                return FEMetricsError(reason="http_status", message=f"HTTP {status}")
+            body = resp.read().decode("utf-8", errors="replace")
+    except TimeoutError:
+        return FEMetricsError(reason="timeout", message=f"timeout after {timeout}s")
+    except urllib.error.HTTPError as exc:
+        return FEMetricsError(reason="http_status", message=f"HTTP {exc.code}")
+    except urllib.error.URLError as exc:
+        return FEMetricsError(reason="network", message=str(exc.reason))
+    except Exception as exc:  # noqa: BLE001  - graceful degradation is the goal
+        logger.debug("Unexpected /metrics fetch error for %s:%s: %s", host, http_port, exc)
+        return FEMetricsError(reason="unknown", message=str(exc))
+
+    try:
+        return _parse_metrics_body(body)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Parse error for %s:%s: %s", host, http_port, exc)
+        return FEMetricsError(reason="parse", message=str(exc))

--- a/backend/app/utils/cache.py
+++ b/backend/app/utils/cache.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 
 def clear_all_caches() -> None:
-    """Clear all server-side TTL caches (DAG, roles, users)."""
+    """Clear all server-side TTL caches (DAG, roles, users, cluster)."""
     from app.routers.admin_dag import _dag_cache as admin_dag_cache
     from app.routers.admin_roles import _role_cache as admin_role_cache, _role_cache_lock as admin_role_lock
+    from app.routers.cluster import _cluster_cache, _cluster_cache_lock
     from app.routers.user_dag import _dag_cache as user_dag_cache
     from app.routers.user_objects import _catalog_cache, _catalog_cache_lock
     from app.routers.user_roles import _role_cache as user_role_cache, _role_cache_lock as user_role_lock
@@ -22,3 +23,5 @@ def clear_all_caches() -> None:
         user_role_cache.clear()
     with _user_cache_lock:
         _user_cache.clear()
+    with _cluster_cache_lock:
+        _cluster_cache.clear()

--- a/backend/app/utils/sys_access.py
+++ b/backend/app/utils/sys_access.py
@@ -8,12 +8,35 @@ from app.services.starrocks_client import execute_query
 
 logger = logging.getLogger(__name__)
 
+# MySQL error codes that indicate access was denied (authorization failure).
+# 1044: DB access denied · 1045: bad user/password · 1142: table op denied ·
+# 1227: cluster/SYSTEM op denied.
+ACCESS_DENIED_ERRNOS = frozenset({1044, 1045, 1142, 1227})
+
 
 def can_access_sys(conn) -> bool:
-    """Return True if the current connection can query sys.role_edges."""
+    """Return True only if the connection can query all three sys tables used by admin routes.
+
+    Calls SET ROLE ALL first so that non-default roles (e.g. cluster_admin granted
+    but not active by default) are considered in the check.
+    """
     try:
-        execute_query(conn, "SELECT 1 FROM sys.role_edges LIMIT 1")
-        return True
+        execute_query(conn, "SET ROLE ALL")
     except Exception:
-        logger.debug("sys.role_edges not accessible — falling back to SHOW GRANTS")
+        logger.debug("SET ROLE ALL failed during admin check — proceeding without it")
+
+    for table in ("sys.role_edges", "sys.grants_to_users", "sys.grants_to_roles"):
+        try:
+            execute_query(conn, f"SELECT 1 FROM {table} LIMIT 1")
+        except Exception:
+            logger.debug("sys table not accessible (%s) — treating as non-admin", table)
+            return False
+
+    # SHOW ROLES requires user_admin/security_admin — verifies full admin capability
+    try:
+        execute_query(conn, "SHOW ROLES")
+    except Exception:
+        logger.debug("SHOW ROLES denied — treating as non-admin")
         return False
+
+    return True

--- a/backend/app/utils/sys_access.py
+++ b/backend/app/utils/sys_access.py
@@ -14,6 +14,19 @@ logger = logging.getLogger(__name__)
 ACCESS_DENIED_ERRNOS = frozenset({1044, 1045, 1142, 1227})
 
 
+def is_access_denied(exc: Exception) -> bool:
+    """True if exc represents a database access-denied error.
+
+    Checks errno first, falls back to StarRocks' canonical "Access denied"
+    prefix since some access-denied errors come back as ProgrammingError
+    without the standard MySQL errno.
+    """
+    errno = getattr(exc, "errno", None)
+    if errno in ACCESS_DENIED_ERRNOS:
+        return True
+    return "Access denied" in str(exc)
+
+
 def can_access_sys(conn) -> bool:
     """Return True only if the connection can query all three sys tables used by admin routes.
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -231,6 +231,50 @@ DEFAULT_QUERY_MAP: dict[str, list[dict[str, Any]]] = {
     ],
     "SET CATALOG": [],
     "SHOW GRANTS FOR": [],
+    "SHOW FRONTENDS": [
+        {"Name": "fe-01", "IP": "10.0.0.1", "EditLogPort": "9010", "HttpPort": "8030",
+         "QueryPort": "9030", "RpcPort": "9020", "Role": "FOLLOWER", "IsMaster": "true",
+         "ClusterId": "1234", "Join": "true", "Alive": "true",
+         "ReplayedJournalId": "12345", "LastHeartbeat": "2026-04-19 10:00:00",
+         "IsHelper": "true", "ErrMsg": "", "StartTime": "2026-04-15 08:00:00",
+         "Version": "3.2.0"},
+        {"Name": "fe-02", "IP": "10.0.0.2", "EditLogPort": "9010", "HttpPort": "8030",
+         "QueryPort": "9030", "RpcPort": "9020", "Role": "FOLLOWER", "IsMaster": "false",
+         "ClusterId": "1234", "Join": "true", "Alive": "true",
+         "ReplayedJournalId": "12340", "LastHeartbeat": "2026-04-19 10:00:00",
+         "IsHelper": "true", "ErrMsg": "", "StartTime": "2026-04-15 08:00:00",
+         "Version": "3.2.0"},
+    ],
+    "SHOW BACKENDS": [
+        {"BackendId": "10001", "Host": "10.0.1.1", "HeartbeatPort": "9050", "BePort": "9060",
+         "HttpPort": "8040", "BrpcPort": "8060", "LastStartTime": "2026-04-15 08:00:00",
+         "LastHeartbeat": "2026-04-19 10:00:00", "Alive": "true",
+         "SystemDecommissioned": "false", "TabletNum": "1500",
+         "DataUsedCapacity": "256.78 GB", "AvailCapacity": "768 GB", "TotalCapacity": "1.00 TB",
+         "UsedPct": "25.07 %", "MaxDiskUsedPct": "25.07 %", "ErrMsg": "",
+         "Version": "3.2.0", "Status": "OK", "DataTotalCapacity": "1.00 TB",
+         "DataUsedPct": "25.07 %", "CpuCores": "16", "MemUsedPct": "45.2 %",
+         "NumRunningQueries": "2"},
+        {"BackendId": "10002", "Host": "10.0.1.2", "HeartbeatPort": "9050", "BePort": "9060",
+         "HttpPort": "8040", "BrpcPort": "8060", "LastStartTime": "2026-04-10 08:00:00",
+         "LastHeartbeat": "2026-04-19 09:55:00", "Alive": "false",
+         "SystemDecommissioned": "false", "TabletNum": "1200",
+         "DataUsedCapacity": "180.50 GB", "AvailCapacity": "820 GB", "TotalCapacity": "1.00 TB",
+         "UsedPct": "17.63 %", "MaxDiskUsedPct": "17.63 %", "ErrMsg": "Connection refused",
+         "Version": "3.2.0", "Status": "DISCONNECTED", "DataTotalCapacity": "1.00 TB",
+         "DataUsedPct": "17.63 %", "CpuCores": "16", "MemUsedPct": "0.0 %",
+         "NumRunningQueries": "0"},
+    ],
+    "SHOW COMPUTE NODES": [
+        {"ComputeNodeId": "20001", "IP": "10.0.2.1", "HeartbeatPort": "9050", "BePort": "9060",
+         "HttpPort": "8040", "BrpcPort": "8060", "LastStartTime": "2026-04-15 08:00:00",
+         "LastHeartbeat": "2026-04-19 10:00:00", "Alive": "true",
+         "SystemDecommissioned": "false", "ClusterDecommissioned": "false", "ErrMsg": "",
+         "Version": "3.2.0", "CpuCores": "32", "CpuUsedPct": "12.5 %",
+         "MemLimit": "64.0GB", "MemUsedPct": "30.0 %", "NumRunningQueries": "1",
+         "WarehouseName": "default_warehouse", "TabletNum": "278",
+         "DataCacheMetrics": "Status: Normal, DiskUsage: 200MB/10GB, MemUsage: 35.2MB/15.1GB"},
+    ],
 }
 
 
@@ -293,12 +337,14 @@ def client(mock_db, query_map):
     from app.routers.admin_dag import _dag_cache as admin_dag_cache
     from app.routers.user_dag import _dag_cache as user_dag_cache
     from app.services.admin.user_service import _user_cache
+    from app.routers.cluster import _cluster_cache
     _catalog_cache.clear()
     admin_role_cache.clear()
     user_role_cache.clear()
     admin_dag_cache.clear()
     user_dag_cache.clear()
     _user_cache.clear()
+    _cluster_cache.clear()
 
     def _override_credentials(authorization: str = Header(default="")):
         _default = {"host": TEST_HOST, "port": TEST_PORT, "username": TEST_USER,

--- a/backend/tests/test_cluster_status.py
+++ b/backend/tests/test_cluster_status.py
@@ -148,7 +148,7 @@ def test_cluster_status_metrics_aggregation(client, auth_header):
 
 # ── Limited mode (formerly 403) ──
 
-def test_cluster_status_limited_mode(client, auth_header):
+def test_cluster_status_limited_mode(client, auth_header, monkeypatch):
     """When SHOW FRONTENDS is denied, fallback to limited mode with single-FE view."""
     err = mysql.connector.errors.ProgrammingError(
         msg="Access denied for user 'viewer'@'%' to database 'FRONTENDS'",
@@ -165,23 +165,20 @@ def test_cluster_status_limited_mode(client, auth_header):
             raise err
         return original(conn, sql, params)
 
-    cluster_mod.execute_query = _raise_on_show
+    monkeypatch.setattr(cluster_mod, "execute_query", _raise_on_show)
     cluster_mod._cluster_cache.clear()
-    try:
-        resp = client.get("/api/cluster/status", headers=auth_header)
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["mode"] == "limited"
-        # Limited view: one FE placeholder, zero BE/CN
-        assert len(data["frontends"]) == 1
-        assert data["backends"] == []
-        fe = data["frontends"][0]
-        assert fe["role"] == "UNKNOWN"
-        # /metrics stub still fires on the placeholder FE
-        assert fe["jvm_heap_used_pct"] == pytest.approx(5.0)
-    finally:
-        cluster_mod.execute_query = original
-        cluster_mod._cluster_cache.clear()
+    resp = client.get("/api/cluster/status", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["mode"] == "limited"
+    # Limited view: one FE placeholder, zero BE/CN
+    assert len(data["frontends"]) == 1
+    assert data["backends"] == []
+    fe = data["frontends"][0]
+    assert fe["role"] == "UNKNOWN"
+    # /metrics stub still fires on the placeholder FE
+    assert fe["jvm_heap_used_pct"] == pytest.approx(5.0)
+    cluster_mod._cluster_cache.clear()
 
 
 def test_cluster_status_metrics_all_fail_warning(client, auth_header, monkeypatch):
@@ -236,9 +233,8 @@ def test_cluster_status_metrics_partial_fail(client, auth_header, monkeypatch):
 
 # ── Empty result ──
 
-def test_cluster_status_empty(client, auth_header, query_map):
+def test_cluster_status_empty(client, auth_header, query_map, monkeypatch):
     """SHOW FRONTENDS/BACKENDS returning [] → 200 with empty lists and fe_alive=0."""
-    # Override by patching execute_query
     import app.routers.cluster as cluster_mod
 
     original = cluster_mod.execute_query
@@ -249,26 +245,23 @@ def test_cluster_status_empty(client, auth_header, query_map):
             return []
         return original(conn, sql, params)
 
-    cluster_mod.execute_query = _empty
+    monkeypatch.setattr(cluster_mod, "execute_query", _empty)
     cluster_mod._cluster_cache.clear()
-    try:
-        resp = client.get("/api/cluster/status", headers=auth_header)
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["frontends"] == []
-        assert data["backends"] == []
-        assert data["metrics"]["fe_alive"] == 0
-        assert data["has_errors"] is False
-        # With no FE nodes, there's nothing to probe; no warning.
-        assert data["metrics_warning"] is None
-    finally:
-        cluster_mod.execute_query = original
-        cluster_mod._cluster_cache.clear()
+    resp = client.get("/api/cluster/status", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["frontends"] == []
+    assert data["backends"] == []
+    assert data["metrics"]["fe_alive"] == 0
+    assert data["has_errors"] is False
+    # With no FE nodes, there's nothing to probe; no warning.
+    assert data["metrics_warning"] is None
+    cluster_mod._cluster_cache.clear()
 
 
 # ── Cache test ──
 
-def test_cluster_status_cached(client, auth_header):
+def test_cluster_status_cached(client, auth_header, monkeypatch):
     """Second call must use the cache — expensive queries only run once."""
     import app.routers.cluster as cluster_mod
 
@@ -281,18 +274,16 @@ def test_cluster_status_cached(client, auth_header):
             show_calls += 1
         return original(conn, sql, params)
 
-    cluster_mod.execute_query = _counting
+    monkeypatch.setattr(cluster_mod, "execute_query", _counting)
     cluster_mod._cluster_cache.clear()
-    try:
-        resp1 = client.get("/api/cluster/status", headers=auth_header)
-        assert resp1.status_code == 200
-        resp2 = client.get("/api/cluster/status", headers=auth_header)
-        assert resp2.status_code == 200
 
-        # First request: 3 SHOW calls (SHOW FRONTENDS + SHOW BACKENDS + SHOW COMPUTE NODES).
-        # Second request: served from cache → still 3 total.
-        # (SET ROLE ALL runs each time but it is cheap, so we don't count it.)
-        assert show_calls == 3
-    finally:
-        cluster_mod.execute_query = original
-        cluster_mod._cluster_cache.clear()
+    resp1 = client.get("/api/cluster/status", headers=auth_header)
+    assert resp1.status_code == 200
+    resp2 = client.get("/api/cluster/status", headers=auth_header)
+    assert resp2.status_code == 200
+
+    # First request: 3 SHOW calls (SHOW FRONTENDS + SHOW BACKENDS + SHOW COMPUTE NODES).
+    # Second request: served from cache → still 3 total.
+    # (SET ROLE ALL runs each time but it is cheap, so we don't count it.)
+    assert show_calls == 3
+    cluster_mod._cluster_cache.clear()

--- a/backend/tests/test_cluster_status.py
+++ b/backend/tests/test_cluster_status.py
@@ -1,0 +1,298 @@
+"""Tests for GET /api/cluster/status endpoint."""
+
+from __future__ import annotations
+
+import mysql.connector.errors
+import pytest
+
+from app.services.fe_metrics import FEMetricsData, FEMetricsError
+
+
+@pytest.fixture(autouse=True)
+def _stub_fe_metrics(monkeypatch):
+    """Default: return a deterministic FEMetricsData so tests don't hit the network."""
+    def _fake(host, http_port, timeout=2.0):
+        return FEMetricsData(
+            heap_used_pct=5.0,
+            gc_young_count=100,
+            gc_young_time_ms=2500,
+            gc_old_count=0,
+            gc_old_time_ms=0,
+            query_p99_ms=12.3,
+        )
+    import app.routers.cluster as cluster_mod
+    monkeypatch.setattr(cluster_mod, "fetch_fe_metrics", _fake)
+
+
+# ── Happy path ──
+
+def test_cluster_status_happy_path(client, auth_header):
+    resp = client.get("/api/cluster/status", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert "frontends" in data
+    assert "backends" in data
+    assert "metrics" in data
+    assert "has_errors" in data
+    assert data["mode"] == "full"
+    assert data["metrics_warning"] is None
+
+    assert isinstance(data["frontends"], list)
+    assert len(data["frontends"]) == 2
+
+    # 2 BE + 1 CN from fixture
+    assert isinstance(data["backends"], list)
+    assert len(data["backends"]) == 3
+
+    metrics = data["metrics"]
+    assert "fe_total" in metrics
+    assert "fe_alive" in metrics
+    assert "be_total" in metrics
+    assert "be_alive" in metrics
+    assert "cn_total" in metrics
+    assert "cn_alive" in metrics
+
+    # /metrics injection: stubbed fake returns 5.0 for all FE
+    for fe in data["frontends"]:
+        assert fe["jvm_heap_used_pct"] == pytest.approx(5.0)
+        assert fe["gc_young_count"] == 100
+        assert fe["query_p99_ms"] == pytest.approx(12.3)
+        assert fe["metrics_error"] is None
+    assert metrics["avg_fe_heap_used_pct"] == pytest.approx(5.0)
+
+
+# ── Leader detection ──
+
+def test_cluster_status_leader_detection(client, auth_header):
+    resp = client.get("/api/cluster/status", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    fe_by_name = {fe["name"]: fe for fe in data["frontends"]}
+
+    # fe-01 has IsMaster=true → role must be LEADER
+    assert "fe-01" in fe_by_name
+    assert fe_by_name["fe-01"]["role"] == "LEADER"
+
+    # fe-02 has IsMaster=false → role should be FOLLOWER
+    assert "fe-02" in fe_by_name
+    assert fe_by_name["fe-02"]["role"] == "FOLLOWER"
+
+
+# ── Percentage / int parsing ──
+
+def test_cluster_status_be_pct_parsing(client, auth_header):
+    resp = client.get("/api/cluster/status", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # BackendId 10001 is be-01 (first backend in fixture)
+    be01 = next(b for b in data["backends"] if b["name"] == "10001")
+
+    assert be01["node_type"] == "backend"
+    assert be01["used_pct"] == pytest.approx(25.07)
+    assert be01["cpu_cores"] == 16
+
+
+def test_cluster_status_cn_row(client, auth_header):
+    """Compute node row is mapped with node_type='compute', populates cpu_used_pct,
+    warehouse, and cache-disk usage parsed from DataCacheMetrics."""
+    resp = client.get("/api/cluster/status", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    cn = next(b for b in data["backends"] if b["node_type"] == "compute")
+    assert cn["name"] == "20001"
+    assert cn["cpu_used_pct"] == pytest.approx(12.5)
+    assert cn["warehouse"] == "default_warehouse"
+    assert cn["mem_limit"] == "64.0GB"
+    assert cn["tablet_count"] == 278
+    # Data cache parsed from "DiskUsage: 200MB/10GB"
+    assert cn["data_used_capacity"] == "200MB"
+    assert cn["total_capacity"] == "10GB"
+    # 200MB / 10GB = 200 / 10240 ≈ 1.95%
+    assert cn["used_pct"] == pytest.approx(1.95, abs=0.05)
+
+
+# ── has_errors flag ──
+
+def test_cluster_status_has_errors_flag(client, auth_header):
+    """Default fixture has be-02 with Alive=false and ErrMsg='Connection refused' → has_errors=True."""
+    resp = client.get("/api/cluster/status", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["has_errors"] is True
+
+
+# ── Metrics aggregation ──
+
+def test_cluster_status_metrics_aggregation(client, auth_header):
+    resp = client.get("/api/cluster/status", headers=auth_header)
+    assert resp.status_code == 200
+    metrics = resp.json()["metrics"]
+
+    assert metrics["fe_alive"] == 2
+    assert metrics["fe_total"] == 2
+    assert metrics["be_alive"] == 1
+    assert metrics["be_total"] == 2
+    assert metrics["cn_alive"] == 1
+    assert metrics["cn_total"] == 1
+    # 1500 + 1200 + 278 = 2978
+    assert metrics["total_tablets"] == 2978
+    # Only CN has CpuUsedPct populated → avg == 12.5
+    assert metrics["avg_cpu_used_pct"] == pytest.approx(12.5)
+    # All nodes contribute used_pct: BE 25.07 + BE 17.63 + CN ~1.95 → avg ~14.88
+    assert metrics["avg_disk_used_pct"] == pytest.approx(14.88, abs=0.1)
+
+
+# ── Limited mode (formerly 403) ──
+
+def test_cluster_status_limited_mode(client, auth_header):
+    """When SHOW FRONTENDS is denied, fallback to limited mode with single-FE view."""
+    err = mysql.connector.errors.ProgrammingError(
+        msg="Access denied for user 'viewer'@'%' to database 'FRONTENDS'",
+        errno=1044,
+    )
+
+    import app.routers.cluster as cluster_mod
+
+    original = cluster_mod.execute_query
+
+    def _raise_on_show(conn, sql, params=None):
+        up = sql.strip().upper()
+        if up.startswith("SHOW "):
+            raise err
+        return original(conn, sql, params)
+
+    cluster_mod.execute_query = _raise_on_show
+    cluster_mod._cluster_cache.clear()
+    try:
+        resp = client.get("/api/cluster/status", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["mode"] == "limited"
+        # Limited view: one FE placeholder, zero BE/CN
+        assert len(data["frontends"]) == 1
+        assert data["backends"] == []
+        fe = data["frontends"][0]
+        assert fe["role"] == "UNKNOWN"
+        # /metrics stub still fires on the placeholder FE
+        assert fe["jvm_heap_used_pct"] == pytest.approx(5.0)
+    finally:
+        cluster_mod.execute_query = original
+        cluster_mod._cluster_cache.clear()
+
+
+def test_cluster_status_metrics_all_fail_warning(client, auth_header, monkeypatch):
+    """All FE /metrics calls fail → metrics_warning set, each FE carries its error."""
+    import app.routers.cluster as cluster_mod
+
+    def _err(host, http_port, timeout=2.0):
+        return FEMetricsError(reason="timeout", message=f"timeout after {timeout}s")
+
+    monkeypatch.setattr(cluster_mod, "fetch_fe_metrics", _err)
+    cluster_mod._cluster_cache.clear()
+
+    resp = client.get("/api/cluster/status", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["metrics_warning"] is not None
+    assert "8030" in data["metrics_warning"]
+    for fe in data["frontends"]:
+        assert fe["jvm_heap_used_pct"] is None
+        assert fe["metrics_error"] is not None
+        assert "timeout" in fe["metrics_error"]
+    assert data["metrics"]["avg_fe_heap_used_pct"] is None
+
+
+def test_cluster_status_metrics_partial_fail(client, auth_header, monkeypatch):
+    """One FE succeeds, one fails → no warning; failed FE has metrics_error set."""
+    import app.routers.cluster as cluster_mod
+
+    call_state = {"n": 0}
+
+    def _mixed(host, http_port, timeout=2.0):
+        call_state["n"] += 1
+        if call_state["n"] == 1:
+            return FEMetricsData(heap_used_pct=12.5, query_p99_ms=7.0)
+        return FEMetricsError(reason="network", message="Connection refused")
+
+    monkeypatch.setattr(cluster_mod, "fetch_fe_metrics", _mixed)
+    cluster_mod._cluster_cache.clear()
+
+    resp = client.get("/api/cluster/status", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["metrics_warning"] is None  # at least one succeeded
+    fes = data["frontends"]
+    succ = [fe for fe in fes if fe["jvm_heap_used_pct"] is not None]
+    fail = [fe for fe in fes if fe["jvm_heap_used_pct"] is None]
+    assert len(succ) == 1 and len(fail) == 1
+    assert fail[0]["metrics_error"] is not None
+    # Aggregate is computed only from the successful one
+    assert data["metrics"]["avg_fe_heap_used_pct"] == pytest.approx(12.5)
+
+
+# ── Empty result ──
+
+def test_cluster_status_empty(client, auth_header, query_map):
+    """SHOW FRONTENDS/BACKENDS returning [] → 200 with empty lists and fe_alive=0."""
+    # Override by patching execute_query
+    import app.routers.cluster as cluster_mod
+
+    original = cluster_mod.execute_query
+
+    def _empty(conn, sql, params=None):
+        s = sql.upper()
+        if "FRONTENDS" in s or "BACKENDS" in s or "COMPUTE NODES" in s:
+            return []
+        return original(conn, sql, params)
+
+    cluster_mod.execute_query = _empty
+    cluster_mod._cluster_cache.clear()
+    try:
+        resp = client.get("/api/cluster/status", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["frontends"] == []
+        assert data["backends"] == []
+        assert data["metrics"]["fe_alive"] == 0
+        assert data["has_errors"] is False
+        # With no FE nodes, there's nothing to probe; no warning.
+        assert data["metrics_warning"] is None
+    finally:
+        cluster_mod.execute_query = original
+        cluster_mod._cluster_cache.clear()
+
+
+# ── Cache test ──
+
+def test_cluster_status_cached(client, auth_header):
+    """Second call must use the cache — expensive queries only run once."""
+    import app.routers.cluster as cluster_mod
+
+    show_calls = 0
+    original = cluster_mod.execute_query
+
+    def _counting(conn, sql, params=None):
+        nonlocal show_calls
+        if sql.strip().upper().startswith("SHOW "):
+            show_calls += 1
+        return original(conn, sql, params)
+
+    cluster_mod.execute_query = _counting
+    cluster_mod._cluster_cache.clear()
+    try:
+        resp1 = client.get("/api/cluster/status", headers=auth_header)
+        assert resp1.status_code == 200
+        resp2 = client.get("/api/cluster/status", headers=auth_header)
+        assert resp2.status_code == 200
+
+        # First request: 3 SHOW calls (SHOW FRONTENDS + SHOW BACKENDS + SHOW COMPUTE NODES).
+        # Second request: served from cache → still 3 total.
+        # (SET ROLE ALL runs each time but it is cheap, so we don't count it.)
+        assert show_calls == 3
+    finally:
+        cluster_mod.execute_query = original
+        cluster_mod._cluster_cache.clear()

--- a/backend/tests/test_fe_metrics.py
+++ b/backend/tests/test_fe_metrics.py
@@ -1,0 +1,111 @@
+"""Unit tests for the FE /metrics parser."""
+
+from __future__ import annotations
+
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from app.services.fe_metrics import (
+    FEMetricsData,
+    FEMetricsError,
+    _parse_metrics_body,
+    fetch_fe_metrics,
+)
+
+
+SAMPLE_FULL = """\
+jvm_heap_size_bytes{type="used"} 400000000
+jvm_heap_size_bytes{type="max"} 8000000000
+jvm_heap_size_bytes{type="committed"} 1000000000
+jvm_young_gc{type="count"} 8694
+jvm_young_gc{type="time"} 23370
+jvm_old_gc{type="count"} 2
+jvm_old_gc{type="time"} 150
+starrocks_fe_query_latency{type="50_quantile"} 1.2
+starrocks_fe_query_latency{type="95_quantile"} 4.8
+starrocks_fe_query_latency{type="99_quantile"} 9.7
+starrocks_fe_unrelated_metric 42
+"""
+
+
+def test_parse_full_payload():
+    data = _parse_metrics_body(SAMPLE_FULL)
+    assert isinstance(data, FEMetricsData)
+    assert data.heap_used_pct == pytest.approx(5.0)  # 400M / 8G * 100
+    assert data.gc_young_count == 8694
+    assert data.gc_young_time_ms == 23370
+    assert data.gc_old_count == 2
+    assert data.gc_old_time_ms == 150
+    assert data.query_p99_ms == pytest.approx(9.7)
+
+
+def test_parse_missing_lines_partial_none():
+    body = 'jvm_heap_size_bytes{type="used"} 100\njvm_heap_size_bytes{type="max"} 1000'
+    data = _parse_metrics_body(body)
+    assert data.heap_used_pct == pytest.approx(10.0)
+    assert data.gc_young_count is None
+    assert data.gc_old_count is None
+    assert data.query_p99_ms is None
+
+
+def test_parse_empty_body():
+    data = _parse_metrics_body("")
+    assert all(v is None for v in data.__dict__.values())
+
+
+def test_parse_max_zero_heap_pct_none():
+    body = 'jvm_heap_size_bytes{type="used"} 100\njvm_heap_size_bytes{type="max"} 0'
+    data = _parse_metrics_body(body)
+    assert data.heap_used_pct is None
+
+
+def test_fetch_network_error():
+    with patch("app.services.fe_metrics.urllib.request.urlopen") as m:
+        m.side_effect = urllib.error.URLError("Connection refused")
+        result = fetch_fe_metrics("nohost", 8030, timeout=0.1)
+    assert isinstance(result, FEMetricsError)
+    assert result.reason == "network"
+
+
+def test_fetch_timeout():
+    with patch("app.services.fe_metrics.urllib.request.urlopen") as m:
+        m.side_effect = TimeoutError("timed out")
+        result = fetch_fe_metrics("nohost", 8030, timeout=0.1)
+    assert isinstance(result, FEMetricsError)
+    assert result.reason == "timeout"
+
+
+def test_fetch_http_error_status():
+    class _FakeHTTPError(urllib.error.HTTPError):
+        def __init__(self):
+            super().__init__(url="http://x", code=500, msg="Server Error", hdrs=None, fp=None)
+
+    with patch("app.services.fe_metrics.urllib.request.urlopen") as m:
+        m.side_effect = _FakeHTTPError()
+        result = fetch_fe_metrics("nohost", 8030, timeout=0.1)
+    assert isinstance(result, FEMetricsError)
+    assert result.reason == "http_status"
+    assert "500" in result.message
+
+
+def test_fetch_success_parses_body():
+    class _FakeResp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return SAMPLE_FULL.encode()
+
+    with patch("app.services.fe_metrics.urllib.request.urlopen") as m:
+        m.return_value = _FakeResp()
+        result = fetch_fe_metrics("host", 8030, timeout=0.1)
+    assert isinstance(result, FEMetricsData)
+    assert result.heap_used_pct == pytest.approx(5.0)
+    assert result.query_p99_ms == pytest.approx(9.7)

--- a/docs/API.md
+++ b/docs/API.md
@@ -80,6 +80,11 @@ curl http://localhost:8001/api/admin/roles \
 | GET | `/api/admin/search?q=keyword&limit=50` | Unified search (all objects/users/roles) |
 | GET | `/api/admin/search/users-roles?q=keyword` | Fast user/role search |
 
+### Cluster Routes (`/api/cluster/*` — any logged-in user; StarRocks enforces privilege)
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/cluster/status` | FE/BE node list + aggregate metrics + has_errors flag |
+
 ---
 
 ## Authentication
@@ -562,7 +567,141 @@ Returns the role hierarchy DAG. Structure: root (top) → built-in roles → cus
 
 ---
 
-## 6. Health Check
+## 6. Cluster API
+
+### GET `/api/cluster/status`
+
+Returns FE/BE/CN node health and aggregate cluster metrics. Designed as a **common view** for every logged-in user — non-privileged users see a limited view instead of a 403.
+
+**Auth**: Requires JWT Bearer token. `SHOW FRONTENDS`/`SHOW BACKENDS`/`SHOW COMPUTE NODES` require `cluster_admin` (or SYSTEM OPERATE). When denied, the backend falls back to `mode="limited"` with a single placeholder FE for the host the caller is connected to.
+
+FE resource metrics (heap, GC, p99) come from each FE's unauthenticated Prometheus `/metrics` endpoint on port 8030, fetched in parallel with a 2 s per-node timeout. Unreachable endpoints surface as `metrics_error` on the specific FE and — if **every** FE probe fails — a top-level `metrics_warning`.
+
+**Response** `200 OK` (full mode, K8s-style Shared-Data cluster)
+```json
+{
+  "mode": "full",
+  "frontends": [
+    {
+      "name": "starrocks-oss-fe-0_9010_1775306864789",
+      "ip": "10.100.1.2",
+      "edit_log_port": 9010, "http_port": 8030, "query_port": 9030, "rpc_port": 9020,
+      "role": "LEADER", "alive": true, "join": true,
+      "last_heartbeat": "2026-04-19 10:00:00",
+      "replayed_journal_id": 12345, "start_time": "2026-04-15 08:00:00",
+      "version": "3.2.0", "err_msg": null,
+      "jvm_heap_used_pct": 9.8,
+      "gc_young_count": 8703, "gc_young_time_ms": 23400,
+      "gc_old_count": 0, "gc_old_time_ms": 0,
+      "query_p99_ms": 12.3,
+      "metrics_error": null
+    }
+  ],
+  "backends": [
+    {
+      "name": "20001",
+      "ip": "starrocks-oss-cn-0.starrocks-oss-cn-search.starrocks-oss.svc.cluster.local",
+      "node_type": "compute",
+      "heartbeat_port": 9050, "be_port": 9060, "http_port": 8040, "brpc_port": 8060,
+      "alive": true,
+      "last_heartbeat": "2026-04-19 10:00:00", "last_start_time": "2026-04-15 08:00:00",
+      "tablet_count": 278,
+      "data_used_capacity": "200MB", "total_capacity": "10GB", "used_pct": 1.95,
+      "cpu_cores": 32, "cpu_used_pct": 12.5,
+      "mem_used_pct": 30.0, "mem_limit": "64.0GB",
+      "num_running_queries": 1,
+      "warehouse": "default_warehouse",
+      "version": "3.2.0", "err_msg": null
+    }
+  ],
+  "metrics": {
+    "fe_total": 1, "fe_alive": 1,
+    "be_total": 0, "be_alive": 0,
+    "cn_total": 1, "cn_alive": 1,
+    "total_tablets": 278,
+    "total_data_used": null,
+    "avg_disk_used_pct": 1.95,
+    "avg_cpu_used_pct": 12.5,
+    "avg_mem_used_pct": 30.0,
+    "avg_fe_heap_used_pct": 9.8
+  },
+  "has_errors": false,
+  "metrics_warning": null
+}
+```
+
+**Response Schema**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| mode | `"full"` \| `"limited"` | `"limited"` when `SHOW FRONTENDS` is denied — only a placeholder FE is returned |
+| frontends | FENodeInfo[] | FE nodes |
+| backends | BENodeInfo[] | Backends **and** Compute Nodes (distinguished by `node_type`) |
+| metrics | ClusterMetrics | Aggregate metrics |
+| has_errors | boolean | True if any node is not alive or reports `err_msg` |
+| metrics_warning | string\|null | Set when every FE `/metrics` probe failed (network reachability issue) |
+
+**FENodeInfo**
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | FE identifier (K8s format: `<hostname>_<editLogPort>_<startupTs>`) |
+| ip | string | IP address (SHOW FRONTENDS `IP` column) |
+| edit_log_port / http_port / query_port / rpc_port | integer\|null | StarRocks FE ports |
+| role | `"LEADER"` \| `"FOLLOWER"` \| `"OBSERVER"` \| `"UNKNOWN"` | LEADER is derived from `IsMaster=true` |
+| alive / join | boolean | Heartbeat status |
+| last_heartbeat / start_time | string\|null | Timestamps |
+| replayed_journal_id | integer\|null | |
+| version / err_msg | string\|null | |
+| jvm_heap_used_pct | float\|null | From `/metrics` (`jvm_heap_size_bytes{type="used"}/{type="max"}`) |
+| gc_young_count / gc_young_time_ms | integer\|null | Cumulative YoungGC counters from `/metrics` |
+| gc_old_count / gc_old_time_ms | integer\|null | Cumulative OldGC counters |
+| query_p99_ms | float\|null | `starrocks_fe_query_latency{type="99_quantile"}` |
+| metrics_error | string\|null | Non-null if the FE's `/metrics` probe failed (`timeout` / `network` / `http_status` / `parse`) |
+
+**BENodeInfo** (shared schema for BE and CN)
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | `BackendId` (BE) or `ComputeNodeId` (CN), numeric |
+| ip | string | `Host` column from SHOW BACKENDS / `IP` from SHOW COMPUTE NODES (may be a K8s FQDN) |
+| node_type | `"backend"` \| `"compute"` | Distinguishes BE vs CN |
+| heartbeat_port / be_port / http_port / brpc_port | integer\|null | |
+| alive | boolean | |
+| last_heartbeat / last_start_time | string\|null | |
+| tablet_count | integer\|null | |
+| data_used_capacity / total_capacity | string\|null | Human-readable (e.g. `"256.78 GB"`). For CN, extracted from `DataCacheMetrics` (local cache usage, not persistent storage). |
+| used_pct | float\|null | Disk utilization (BE) or cache utilization (CN) percentage |
+| cpu_cores | integer\|null | Reported in SHOW BACKENDS / SHOW COMPUTE NODES |
+| cpu_used_pct | float\|null | **CN only** — BE does not report CPU usage |
+| mem_used_pct | float\|null | |
+| mem_limit | string\|null | **CN only** — e.g. `"64.0GB"` from `MemLimit` |
+| num_running_queries | integer\|null | |
+| warehouse | string\|null | **CN only** — warehouse name |
+| version / err_msg | string\|null | |
+
+**ClusterMetrics**
+| Field | Type | Description |
+|-------|------|-------------|
+| fe_total / fe_alive | integer | FE counts |
+| be_total / be_alive | integer | BE-only counts (excludes CN) |
+| cn_total / cn_alive | integer | CN-only counts |
+| total_tablets | integer\|null | Sum of tablet counts across BE + CN |
+| total_data_used | string\|null | Sum of `data_used_capacity` across BE nodes only (not cache). Null when no BE |
+| avg_disk_used_pct | float\|null | Avg of `used_pct` across all nodes that report it |
+| avg_cpu_used_pct | float\|null | Avg of `cpu_used_pct` (CN only) |
+| avg_mem_used_pct | float\|null | Avg of `mem_used_pct` across all nodes that report it |
+| avg_fe_heap_used_pct | float\|null | Avg of `jvm_heap_used_pct` across FEs whose `/metrics` succeeded |
+
+> **Cache**: Results are cached per `{username}:{mode}` for `SRPM_CACHE_TTL_SECONDS` (default: 60 s). The cache key includes `mode` so a user's full / limited results never collide.
+
+**Example curl**
+```bash
+curl http://localhost:8001/api/cluster/status \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## 7. Health Check
 
 ### GET `/api/health`
 
@@ -586,6 +725,7 @@ All errors follow this format:
 | Status | Description |
 |--------|-------------|
 | 401 | Authentication failure (invalid token, expired, StarRocks connection failed) |
+| 403 | Authorization failure (non-admin accessing admin route; or insufficient StarRocks privilege, e.g. cluster_admin required) |
 | 422 | Request parameter validation failure |
 | 500 | Internal server error |
 

--- a/frontend/icons/close.svg
+++ b/frontend/icons/close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>

--- a/frontend/icons/info.svg
+++ b/frontend/icons/info.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#3b82f6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>

--- a/frontend/icons/refresh.svg
+++ b/frontend/icons/refresh.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"/><path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14"/></svg>

--- a/frontend/icons/warning.svg
+++ b/frontend/icons/warning.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { C } from "./utils/colors";
 import ExportPngBtn from "./components/common/ExportPngBtn";
 import PermissionDetailTab from "./components/tabs/PermissionDetailTab";
 import InventoryTab from "./components/tabs/InventoryTab";
+import ClusterDrawer from "./components/cluster/ClusterDrawer";
 
 const TAB_CONFIG: { id: TabId; label: string; icon: string; disabled?: boolean; adminOnly?: boolean }[] = [
   { id: "obj", label: "Object Hierarchy", icon: '<rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/>' },
@@ -60,8 +61,15 @@ export default function App() {
     }))
   );
 
-  const isAdmin = user?.is_user_admin ?? true;
+  const isAdmin = user?.is_user_admin ?? false;
   const visibleTabs = TAB_CONFIG.filter((t) => !t.adminOnly || isAdmin);
+
+  // Redirect away from admin-only tabs if user is not admin (e.g. URL hash was #perm)
+  useEffect(() => {
+    if (user && !isAdmin && activeTab === "perm") {
+      setActiveTab("obj");
+    }
+  }, [user, isAdmin, activeTab, setActiveTab]);
 
   const [dagState, setDagState] = useState<{ cache: Record<string, DAGGraph | null>; loading: boolean }>({
     cache: {}, loading: false,
@@ -84,7 +92,7 @@ export default function App() {
   // Load DAG data when tab or catalog changes (skip perm tab - it manages its own DAG)
   const dagKey = `${activeTab}_${activeCatalog}`;
   useEffect(() => {
-    if (!isLoggedIn || activeTab === "perm" || activeTab === "myperm") return;
+    if (!isLoggedIn || !user || activeTab === "perm" || activeTab === "myperm") return;
     if (dagState.cache[dagKey]) return;
     const controller = new AbortController();
     setDagState((prev) => ({ ...prev, loading: true }));
@@ -97,8 +105,8 @@ export default function App() {
       .then((data) => setDagState((prev) => ({ cache: { ...prev.cache, [dagKey]: data }, loading: false })))
       .catch(() => setDagState((prev) => ({ ...prev, loading: false })));
     return () => controller.abort();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only reload on tab/catalog change, dagState.cache checked inside
-  }, [isLoggedIn, activeTab, activeCatalog]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: reload only when tab/catalog changes or user loads (post-refresh); dagState.cache checked inside
+  }, [isLoggedIn, user, isAdmin, activeTab, activeCatalog]);
 
   const rawDag = dagState.cache[dagKey] || null;
   const loading = dagState.loading;
@@ -150,7 +158,7 @@ export default function App() {
           {/* Content area */}
           {activeTab === "myperm" ? (
             <InventoryTab />
-          ) : activeTab === "perm" ? (
+          ) : activeTab === "perm" && isAdmin ? (
             <PermissionDetailTab />
           ) : (
             <div style={{ flex: 1, position: "relative", background: C.bg }}>
@@ -219,6 +227,7 @@ export default function App() {
           </div>
         )}
       </div>
+      <ClusterDrawer />
     </div>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import ExportPngBtn from "./components/common/ExportPngBtn";
 import PermissionDetailTab from "./components/tabs/PermissionDetailTab";
 import InventoryTab from "./components/tabs/InventoryTab";
 import ClusterDrawer from "./components/cluster/ClusterDrawer";
+import { Loader } from "./components/tabs/inventory-ui";
 
 const TAB_CONFIG: { id: TabId; label: string; icon: string; disabled?: boolean; adminOnly?: boolean }[] = [
   { id: "obj", label: "Object Hierarchy", icon: '<rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/>' },
@@ -116,6 +117,7 @@ export default function App() {
   useEffect(() => { setDagData(rawDag); }, [dagKey, dagState.cache]);
 
   if (!isLoggedIn) return <LoginForm />;
+  if (!user) return <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh" }}><Loader /></div>;  // restoring session
 
   const direction = "TB";
 

--- a/frontend/src/api/cluster.test.ts
+++ b/frontend/src/api/cluster.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockApiFetch = vi.fn();
+
+vi.mock("./client", () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+import { getClusterStatus } from "./cluster";
+
+beforeEach(() => {
+  mockApiFetch.mockReset();
+  mockApiFetch.mockResolvedValue({});
+});
+
+describe("cluster API", () => {
+  it("getClusterStatus calls /cluster/status", async () => {
+    await getClusterStatus();
+    expect(mockApiFetch).toHaveBeenCalledWith("/cluster/status", expect.any(Object));
+  });
+
+  it("getClusterStatus forwards AbortSignal", async () => {
+    const controller = new AbortController();
+    await getClusterStatus(controller.signal);
+    expect(mockApiFetch).toHaveBeenCalledWith("/cluster/status", {
+      signal: controller.signal,
+    });
+  });
+
+  it("getClusterStatus works without AbortSignal", async () => {
+    await getClusterStatus();
+    const [, opts] = mockApiFetch.mock.calls[0] as [string, { signal?: AbortSignal }];
+    expect(opts.signal).toBeUndefined();
+  });
+
+  it("getClusterStatus returns the API response", async () => {
+    const mockResponse = {
+      frontends: [],
+      backends: [],
+      metrics: {
+        fe_total: 0,
+        fe_alive: 0,
+        be_total: 0,
+        be_alive: 0,
+        cn_total: 0,
+        cn_alive: 0,
+        total_tablets: null,
+        total_data_used: null,
+        avg_disk_used_pct: null,
+        avg_cpu_used_pct: null,
+        avg_mem_used_pct: null,
+        avg_fe_heap_used_pct: null,
+      },
+      has_errors: false,
+      mode: "full" as const,
+      metrics_warning: null,
+    };
+    mockApiFetch.mockResolvedValue(mockResponse);
+    const result = await getClusterStatus();
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("getClusterStatus propagates errors from apiFetch", async () => {
+    mockApiFetch.mockRejectedValue(new Error("403: cluster_admin role required"));
+    await expect(getClusterStatus()).rejects.toThrow("403: cluster_admin role required");
+  });
+});

--- a/frontend/src/api/cluster.ts
+++ b/frontend/src/api/cluster.ts
@@ -1,0 +1,11 @@
+/**
+ * API client for /api/cluster/* endpoints.
+ * Not under /api/user or /api/admin because this endpoint is reachable by any
+ * logged-in user — StarRocks itself enforces cluster_admin/SYSTEM OPERATE.
+ * On insufficient StarRocks privileges, the server returns 403.
+ */
+import { apiFetch } from "./client";
+import type { ClusterStatusResponse } from "../types";
+
+export const getClusterStatus = (signal?: AbortSignal) =>
+  apiFetch<ClusterStatusResponse>("/cluster/status", { signal });

--- a/frontend/src/components/cluster/ClusterDrawer.test.tsx
+++ b/frontend/src/components/cluster/ClusterDrawer.test.tsx
@@ -1,0 +1,713 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "../../test/test-utils";
+import ClusterDrawer from "./ClusterDrawer";
+import { useClusterStore } from "../../stores/clusterStore";
+import type { ClusterStatusResponse } from "../../types";
+
+/* ── Mocks ── */
+
+const mockGetClusterStatus = vi.fn();
+vi.mock("../../api/cluster", () => ({
+  getClusterStatus: (...args: unknown[]) => mockGetClusterStatus(...args),
+}));
+
+vi.mock("../dag/nodeIcons", () => ({
+  colorizedSvg: (type: string) =>
+    `<svg width="24" height="24"><circle data-type="${type}"/></svg>`,
+  NODE_SVG_RAW: {},
+  NODE_COLORS: {},
+  APP_LOGO_SVG: '<svg width="24" height="24"></svg>',
+}));
+
+/* ── Test data factories ── */
+
+function makeFENode(
+  overrides: Partial<ClusterStatusResponse["frontends"][0]> = {},
+): ClusterStatusResponse["frontends"][0] {
+  return {
+    name: "fe-01",
+    ip: "10.0.0.1",
+    edit_log_port: 9010,
+    http_port: 8030,
+    query_port: 9030,
+    rpc_port: 9020,
+    role: "LEADER",
+    alive: true,
+    join: true,
+    last_heartbeat: null,
+    replayed_journal_id: 12345,
+    start_time: "2026-04-19 10:00:00",
+    version: "3.3.0",
+    err_msg: null,
+    jvm_heap_used_pct: 45.2,
+    gc_young_count: 10,
+    gc_young_time_ms: 500,
+    gc_old_count: 1,
+    gc_old_time_ms: 200,
+    query_p99_ms: 15.3,
+    metrics_error: null,
+    ...overrides,
+  };
+}
+
+function makeBENode(
+  overrides: Partial<ClusterStatusResponse["backends"][0]> = {},
+): ClusterStatusResponse["backends"][0] {
+  return {
+    name: "be-01",
+    ip: "10.0.0.2",
+    node_type: "backend",
+    heartbeat_port: 9050,
+    be_port: 9060,
+    http_port: 8040,
+    brpc_port: 8060,
+    alive: true,
+    last_heartbeat: null,
+    last_start_time: "2026-04-19 10:00:00",
+    tablet_count: 1000,
+    data_used_capacity: "100 GB",
+    total_capacity: "500 GB",
+    used_pct: 20.5,
+    cpu_cores: 8,
+    cpu_used_pct: null,
+    mem_used_pct: 60.3,
+    mem_limit: "16 GB",
+    num_running_queries: 3,
+    warehouse: null,
+    version: "3.3.0",
+    err_msg: null,
+    ...overrides,
+  };
+}
+
+function makeClusterData(
+  overrides: Partial<ClusterStatusResponse> = {},
+): ClusterStatusResponse {
+  return {
+    frontends: [makeFENode()],
+    backends: [makeBENode()],
+    metrics: {
+      fe_total: 1,
+      fe_alive: 1,
+      be_total: 1,
+      be_alive: 1,
+      cn_total: 0,
+      cn_alive: 0,
+      total_tablets: 1000,
+      total_data_used: "100 GB",
+      avg_disk_used_pct: 20.5,
+      avg_cpu_used_pct: null,
+      avg_mem_used_pct: 60.3,
+      avg_fe_heap_used_pct: 45.2,
+    },
+    has_errors: false,
+    mode: "full",
+    metrics_warning: null,
+    ...overrides,
+  };
+}
+
+/* ── Setup ── */
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetClusterStatus.mockResolvedValue(makeClusterData());
+  useClusterStore.setState({ isOpen: false, expandedNodes: new Set<string>() });
+});
+
+/* ── Tests ── */
+
+describe("ClusterDrawer", () => {
+  describe("structural rendering", () => {
+    it("renders Cluster Status title", () => {
+      render(<ClusterDrawer />);
+      expect(screen.getByText("Cluster Status")).toBeInTheDocument();
+    });
+
+    it("renders Refresh and Close buttons", () => {
+      render(<ClusterDrawer />);
+      expect(screen.getByTitle("Refresh")).toBeInTheDocument();
+      expect(screen.getByTitle("Close")).toBeInTheDocument();
+    });
+
+    it("does not fetch when drawer is closed", () => {
+      render(<ClusterDrawer />);
+      expect(mockGetClusterStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("open/close behavior", () => {
+    it("close button calls closeDrawer", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
+
+      screen.getByTitle("Close").click();
+      expect(useClusterStore.getState().isOpen).toBe(false);
+    });
+
+    it("ESC key closes drawer when open", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+
+      await act(async () => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      });
+
+      expect(useClusterStore.getState().isOpen).toBe(false);
+    });
+
+    it("ESC key does nothing when drawer is already closed", () => {
+      render(<ClusterDrawer />);
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      expect(useClusterStore.getState().isOpen).toBe(false);
+    });
+
+    it("backdrop click closes drawer", async () => {
+      useClusterStore.setState({ isOpen: true });
+      const { container } = render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
+
+      const backdrop = container.firstElementChild as HTMLElement;
+      backdrop?.click();
+      expect(useClusterStore.getState().isOpen).toBe(false);
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows loading indicator when open and fetching", async () => {
+      let resolvePromise!: (data: ClusterStatusResponse) => void;
+      mockGetClusterStatus.mockReturnValue(
+        new Promise<ClusterStatusResponse>((res) => { resolvePromise = res; }),
+      );
+
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+
+      expect(screen.getByText("Loading...")).toBeInTheDocument();
+
+      await act(async () => { resolvePromise(makeClusterData()); });
+    });
+
+    it("refresh button is disabled while loading", async () => {
+      let resolvePromise!: (data: ClusterStatusResponse) => void;
+      mockGetClusterStatus.mockReturnValue(
+        new Promise<ClusterStatusResponse>((res) => { resolvePromise = res; }),
+      );
+
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+
+      expect(screen.getByTitle("Refresh")).toBeDisabled();
+
+      await act(async () => { resolvePromise(makeClusterData()); });
+    });
+  });
+
+  describe("error state", () => {
+    it("shows error message on fetch failure", async () => {
+      mockGetClusterStatus.mockRejectedValue(new Error("Network error"));
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+
+      await waitFor(() =>
+        expect(screen.getByText(/Failed to load cluster status/)).toBeInTheDocument(),
+      );
+    });
+
+    it("Retry button re-fetches", async () => {
+      mockGetClusterStatus.mockRejectedValue(new Error("Network error"));
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+
+      await waitFor(() => expect(screen.getByText("Retry")).toBeInTheDocument());
+
+      mockGetClusterStatus.mockResolvedValue(makeClusterData());
+      screen.getByText("Retry").click();
+
+      await waitFor(() => expect(screen.queryByText("Retry")).not.toBeInTheDocument());
+    });
+
+    it("abort error is not shown as an error state", async () => {
+      let rejectPromise!: (err: Error) => void;
+      mockGetClusterStatus.mockReturnValue(
+        new Promise<ClusterStatusResponse>((_, rej) => { rejectPromise = rej; }),
+      );
+
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+
+      await act(async () => {
+        act(() => { useClusterStore.getState().closeDrawer(); });
+        rejectPromise(new DOMException("Request aborted", "AbortError"));
+      });
+
+      expect(screen.queryByText(/Failed to load/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("data rendering — summary section", () => {
+    it("shows FE and BE alive counts", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
+
+      expect(screen.getAllByText(/1\/1/).length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("shows CN alive count when cn_total > 0", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          metrics: {
+            fe_total: 1, fe_alive: 1, be_total: 0, be_alive: 0,
+            cn_total: 2, cn_alive: 1,
+            total_tablets: null, total_data_used: null,
+            avg_disk_used_pct: null, avg_cpu_used_pct: null,
+            avg_mem_used_pct: null, avg_fe_heap_used_pct: null,
+          },
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText(/1\/2/)).toBeInTheDocument());
+    });
+
+    it("shows Avg Disk label", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText(/Avg Disk/)).toBeInTheDocument());
+    });
+
+    it("shows Avg Mem label", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Avg Mem:")).toBeInTheDocument());
+    });
+
+    it("shows Avg FE Heap label", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Avg FE Heap:")).toBeInTheDocument());
+    });
+
+    it("shows Avg CPU when present", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          metrics: {
+            fe_total: 1, fe_alive: 1, be_total: 0, be_alive: 0,
+            cn_total: 1, cn_alive: 1,
+            total_tablets: null, total_data_used: null,
+            avg_disk_used_pct: null, avg_cpu_used_pct: 25.5,
+            avg_mem_used_pct: null, avg_fe_heap_used_pct: null,
+          },
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Avg CPU:")).toBeInTheDocument());
+    });
+
+    it("shows total tablets when present", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText(/Tablets:/)).toBeInTheDocument());
+    });
+
+    it("shows total data used when present", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText(/Data Used:/)).toBeInTheDocument());
+    });
+
+    it("shows Avg Disk/Cache label for mixed BE+CN cluster", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          metrics: {
+            fe_total: 1, fe_alive: 1, be_total: 1, be_alive: 1,
+            cn_total: 1, cn_alive: 1,
+            total_tablets: null, total_data_used: null,
+            avg_disk_used_pct: 30.0, avg_cpu_used_pct: null,
+            avg_mem_used_pct: null, avg_fe_heap_used_pct: null,
+          },
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Avg Disk/Cache:")).toBeInTheDocument());
+    });
+  });
+
+  describe("data rendering — banners and alerts", () => {
+    it("shows limited mode banner when mode=limited", async () => {
+      mockGetClusterStatus.mockResolvedValue(makeClusterData({ mode: "limited" }));
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Limited view")).toBeInTheDocument());
+    });
+
+    it("shows metrics warning banner when present", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({ metrics_warning: "Could not reach FE /metrics endpoint" }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() =>
+        expect(screen.getByText("Could not reach FE /metrics endpoint")).toBeInTheDocument(),
+      );
+    });
+
+    it("shows Alerts section when has_errors is true", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          has_errors: true,
+          frontends: [makeFENode({ alive: false, err_msg: null })],
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Alerts")).toBeInTheDocument());
+    });
+
+    it("alert shows err_msg text when node has an error message", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          has_errors: true,
+          frontends: [makeFENode({ err_msg: "Heartbeat timeout" })],
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Heartbeat timeout")).toBeInTheDocument());
+    });
+  });
+
+  describe("data rendering — section headers", () => {
+    it("shows Frontend Nodes section header", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Frontend Nodes")).toBeInTheDocument());
+    });
+
+    it("shows Backend Nodes section header for BE-only cluster", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Backend Nodes")).toBeInTheDocument());
+    });
+
+    it("shows Compute Nodes header when only CNs", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          backends: [makeBENode({ node_type: "compute" })],
+          metrics: {
+            fe_total: 1, fe_alive: 1, be_total: 0, be_alive: 0,
+            cn_total: 1, cn_alive: 1,
+            total_tablets: null, total_data_used: null,
+            avg_disk_used_pct: null, avg_cpu_used_pct: null,
+            avg_mem_used_pct: null, avg_fe_heap_used_pct: null,
+          },
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Compute Nodes")).toBeInTheDocument());
+    });
+
+    it("shows Backend & Compute Nodes header for mixed cluster", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          backends: [
+            makeBENode({ node_type: "backend" }),
+            makeBENode({ node_type: "compute", name: "cn-01", ip: "10.0.0.3" }),
+          ],
+          metrics: {
+            fe_total: 1, fe_alive: 1, be_total: 1, be_alive: 1,
+            cn_total: 1, cn_alive: 1,
+            total_tablets: null, total_data_used: null,
+            avg_disk_used_pct: null, avg_cpu_used_pct: null,
+            avg_mem_used_pct: null, avg_fe_heap_used_pct: null,
+          },
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() =>
+        expect(screen.getByText("Backend & Compute Nodes")).toBeInTheDocument(),
+      );
+    });
+
+    it("shows No nodes reported for empty FE list", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          frontends: [],
+          metrics: {
+            fe_total: 0, fe_alive: 0, be_total: 1, be_alive: 1,
+            cn_total: 0, cn_alive: 0,
+            total_tablets: null, total_data_used: null,
+            avg_disk_used_pct: null, avg_cpu_used_pct: null,
+            avg_mem_used_pct: null, avg_fe_heap_used_pct: null,
+          },
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("No nodes reported")).toBeInTheDocument());
+    });
+  });
+
+  describe("FE node card", () => {
+    it("shows FE node display name", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
+      expect(screen.getByText("fe-01")).toBeInTheDocument();
+    });
+
+    it("shows LEADER role badge", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("LEADER")).toBeInTheDocument());
+    });
+
+    it("shows OBSERVER role badge", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({ frontends: [makeFENode({ role: "OBSERVER" })] }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("OBSERVER")).toBeInTheDocument());
+    });
+
+    it("shows FOLLOWER role badge (other role)", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({ frontends: [makeFENode({ role: "FOLLOWER" })] }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("FOLLOWER")).toBeInTheDocument());
+    });
+
+    it("shows ALIVE badge for alive FE node", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() =>
+        expect(screen.getAllByText("ALIVE").length).toBeGreaterThan(0),
+      );
+    });
+
+    it("shows DEAD badge for dead FE node", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({ frontends: [makeFENode({ alive: false })] }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("DEAD")).toBeInTheDocument());
+    });
+
+    it("shows Heap metric row when jvm_heap_used_pct is present", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Heap")).toBeInTheDocument());
+    });
+
+    it("shows metrics unavailable message when metrics_error is set", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          frontends: [makeFENode({ jvm_heap_used_pct: null, metrics_error: "Connection refused" })],
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() =>
+        expect(screen.getByText(/Metrics unavailable.*Connection refused/)).toBeInTheDocument(),
+      );
+    });
+
+    it("clicking FE node card header toggles expansion", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
+
+      screen.getByText("fe-01").click();
+      expect(useClusterStore.getState().expandedNodes.has("fe:fe-01")).toBe(true);
+    });
+
+    it("expanded FE node shows Version detail", async () => {
+      useClusterStore.setState({ isOpen: true, expandedNodes: new Set(["fe:fe-01"]) });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Version")).toBeInTheDocument());
+      expect(screen.getAllByText("3.3.0").length).toBeGreaterThan(0);
+    });
+
+    it("expanded FE node shows Journal ID detail", async () => {
+      useClusterStore.setState({ isOpen: true, expandedNodes: new Set(["fe:fe-01"]) });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Journal ID")).toBeInTheDocument());
+    });
+
+    it("expanded FE node shows Young GC and Old GC", async () => {
+      useClusterStore.setState({ isOpen: true, expandedNodes: new Set(["fe:fe-01"]) });
+      render(<ClusterDrawer />);
+      await waitFor(() => {
+        expect(screen.getByText("Young GC (cumulative)")).toBeInTheDocument();
+        expect(screen.getByText("Old GC (cumulative)")).toBeInTheDocument();
+      });
+    });
+
+    it("expanded FE node shows Query p99", async () => {
+      useClusterStore.setState({ isOpen: true, expandedNodes: new Set(["fe:fe-01"]) });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Query p99")).toBeInTheDocument());
+    });
+
+    it("expanded FE node shows err_msg when present", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({ frontends: [makeFENode({ err_msg: "Journal replay failed" })] }),
+      );
+      useClusterStore.setState({ isOpen: true, expandedNodes: new Set(["fe:fe-01"]) });
+      render(<ClusterDrawer />);
+      await waitFor(() =>
+        expect(screen.getByText("Journal replay failed")).toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("BE node card", () => {
+    it("shows BE node display name", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("be-01")).toBeInTheDocument());
+    });
+
+    it("shows BE type badge", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("BE")).toBeInTheDocument());
+    });
+
+    it("shows CN type badge for compute node", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({ backends: [makeBENode({ node_type: "compute" })] }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("CN")).toBeInTheDocument());
+    });
+
+    it("shows tablet count", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText(/1,000 tablets/)).toBeInTheDocument());
+    });
+
+    it("shows Disk metric row for BE", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Disk")).toBeInTheDocument());
+    });
+
+    it("shows Disk Cache label for compute node", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          backends: [makeBENode({ node_type: "compute", used_pct: 30.0 })],
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Disk Cache")).toBeInTheDocument());
+    });
+
+    it("shows CPU metric row for CN with cpu_used_pct", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          backends: [makeBENode({ node_type: "compute", cpu_used_pct: 42.0 })],
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("CPU")).toBeInTheDocument());
+    });
+
+    it("shows Memory metric row", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Memory")).toBeInTheDocument());
+    });
+
+    it("clicking BE node header toggles expansion", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
+
+      screen.getByText("be-01").click();
+      expect(useClusterStore.getState().expandedNodes.has("be:be-01")).toBe(true);
+    });
+
+    it("expanded BE shows CPU Cores and Running Queries", async () => {
+      useClusterStore.setState({ isOpen: true, expandedNodes: new Set(["be:be-01"]) });
+      render(<ClusterDrawer />);
+      await waitFor(() => {
+        expect(screen.getByText("CPU Cores")).toBeInTheDocument();
+        expect(screen.getByText("Running Queries")).toBeInTheDocument();
+      });
+    });
+
+    it("expanded BE shows Last Start detail", async () => {
+      useClusterStore.setState({ isOpen: true, expandedNodes: new Set(["be:be-01"]) });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Last Start")).toBeInTheDocument());
+    });
+
+    it("expanded CN shows Warehouse label", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          backends: [
+            makeBENode({ name: "cn-01", node_type: "compute", warehouse: "default_wh" }),
+          ],
+        }),
+      );
+      useClusterStore.setState({ isOpen: true, expandedNodes: new Set(["cn:cn-01"]) });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Warehouse")).toBeInTheDocument());
+      expect(screen.getByText("default_wh")).toBeInTheDocument();
+    });
+
+    it("expanded BE shows err_msg when present", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({ backends: [makeBENode({ err_msg: "Disk full" })] }),
+      );
+      useClusterStore.setState({ isOpen: true, expandedNodes: new Set(["be:be-01"]) });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("Disk full")).toBeInTheDocument());
+    });
+
+    it("high disk usage (>85%) renders without error", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({ backends: [makeBENode({ used_pct: 90 })] }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("be-01")).toBeInTheDocument());
+    });
+
+    it("mid disk usage (>70%) renders without error", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({ backends: [makeBENode({ used_pct: 75 })] }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.getByText("be-01")).toBeInTheDocument());
+    });
+  });
+
+  describe("refresh button", () => {
+    it("refresh button re-fetches data", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
+
+      expect(mockGetClusterStatus).toHaveBeenCalledTimes(1);
+      screen.getByTitle("Refresh").click();
+      expect(mockGetClusterStatus).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/src/components/cluster/ClusterDrawer.tsx
+++ b/frontend/src/components/cluster/ClusterDrawer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/set-state-in-effect -- setState in effects is intentional; React 18+ auto-batches these calls */
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useClusterStore } from "../../stores/clusterStore";
 import { getClusterStatus } from "../../api/cluster";
@@ -7,6 +6,7 @@ import { shortenNodeName } from "../../utils/nodeNameUtils";
 import type { ClusterStatusResponse, FENodeInfo, BENodeInfo } from "../../types";
 import { C } from "../../utils/colors";
 import { Badge, Loader } from "../tabs/inventory-ui";
+import InlineIcon from "../common/InlineIcon";
 
 /* ── Utilization progress bar (0–100%) ── */
 function UtilBar({ pct }: { pct: number }) {
@@ -291,6 +291,7 @@ export default function ClusterDrawer() {
   // Fetch on open
   useEffect(() => {
     if (isOpen) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- fetchData's sync setState(true/null) is intentional: drawer must enter loading state on open
       fetchData();
     } else {
       // Cancel any in-flight request when closed
@@ -371,7 +372,7 @@ export default function ClusterDrawer() {
             onMouseEnter={(e) => { if (!loading) e.currentTarget.style.color = C.accent; }}
             onMouseLeave={(e) => { e.currentTarget.style.color = C.text2; }}
           >
-            ↻
+            <InlineIcon type="refresh" size={16} />
           </button>
 
           {/* Close button */}
@@ -387,7 +388,7 @@ export default function ClusterDrawer() {
             onMouseEnter={(e) => { e.currentTarget.style.color = "#ef4444"; e.currentTarget.style.borderColor = "#ef4444"; }}
             onMouseLeave={(e) => { e.currentTarget.style.color = C.text2; e.currentTarget.style.borderColor = C.borderLight; }}
           >
-            &times;
+            <InlineIcon type="close" size={16} />
           </button>
         </div>
 
@@ -424,7 +425,7 @@ export default function ClusterDrawer() {
                   background: `${C.accent}12`,
                   fontSize: 12, color: C.text1, display: "flex", gap: 8, alignItems: "flex-start",
                 }}>
-                  <span style={{ fontSize: 14 }}>ℹ️</span>
+                  <span style={{ display: "inline-flex", paddingTop: 1 }}><InlineIcon type="info" size={14} /></span>
                   <span>
                     <strong>Limited view</strong> — showing only the FE you're connected to.
                     Full cluster inventory requires the <code style={{ color: C.accent }}>cluster_admin</code> role.
@@ -440,7 +441,7 @@ export default function ClusterDrawer() {
                   background: `${C.warning}12`,
                   fontSize: 12, color: C.text1, display: "flex", gap: 8, alignItems: "flex-start",
                 }}>
-                  <span style={{ fontSize: 14 }}>⚠️</span>
+                  <span style={{ display: "inline-flex", paddingTop: 1 }}><InlineIcon type="warning" size={14} /></span>
                   <span>{data.metrics_warning}</span>
                 </div>
               )}
@@ -531,7 +532,7 @@ export default function ClusterDrawer() {
               {data.has_errors && (
                 <div style={{ marginBottom: 14 }}>
                   <div style={{ fontSize: 12, fontWeight: 700, color: "#ef4444", marginBottom: 6, display: "flex", alignItems: "center", gap: 6 }}>
-                    <span>⚠</span>
+                    <InlineIcon type="warning" size={14} color="#ef4444" />
                     <span>Alerts</span>
                     <span style={{ color: C.text3, fontWeight: 400 }}>
                       ({[...frontends, ...backends].filter((n) => !n.alive || n.err_msg).length})

--- a/frontend/src/components/cluster/ClusterDrawer.tsx
+++ b/frontend/src/components/cluster/ClusterDrawer.tsx
@@ -1,0 +1,609 @@
+/* eslint-disable react-hooks/set-state-in-effect -- setState in effects is intentional; React 18+ auto-batches these calls */
+import { useEffect, useState, useCallback, useRef } from "react";
+import { useClusterStore } from "../../stores/clusterStore";
+import { getClusterStatus } from "../../api/cluster";
+import { formatRelativeTime } from "../../utils/relativeTime";
+import { shortenNodeName } from "../../utils/nodeNameUtils";
+import type { ClusterStatusResponse, FENodeInfo, BENodeInfo } from "../../types";
+import { C } from "../../utils/colors";
+import { Badge, Loader } from "../tabs/inventory-ui";
+
+/* ── Utilization progress bar (0–100%) ── */
+function UtilBar({ pct }: { pct: number }) {
+  const color = pct > 85 ? "#ef4444" : pct > 70 ? C.warning : C.green;
+  return (
+    <div style={{ width: "100%", height: 6, background: C.border, borderRadius: 3, overflow: "hidden", marginTop: 4 }}>
+      <div style={{ width: `${Math.min(pct, 100)}%`, height: "100%", background: color, borderRadius: 3, transition: "width 0.3s" }} />
+    </div>
+  );
+}
+
+/* ── Labelled utilization row (metric name + bar) ── */
+function MetricRow({ label, pct, extra }: { label: string; pct: number; extra?: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 6 }}>
+      <div style={{ fontSize: 11, color: C.text2, display: "flex", justifyContent: "space-between" }}>
+        <span>{label} <span style={{ color: C.text3 }}>{extra}</span></span>
+        <strong style={{ color: C.text1 }}>{pct.toFixed(1)}%</strong>
+      </div>
+      <UtilBar pct={pct} />
+    </div>
+  );
+}
+
+
+/* ── Status dot ── */
+// Visual optical-center fix: align-items:center lines up box centers, but text's
+// perceived weight sits slightly below its box center, so the dot needs a small
+// downward nudge (0.5px) to *look* centered next to numbers/uppercase labels.
+function StatusDot({ alive }: { alive: boolean }) {
+  return (
+    <span style={{
+      display: "inline-block", width: 8, height: 8, borderRadius: "50%",
+      background: alive ? C.green : "#ef4444", flexShrink: 0,
+      boxShadow: alive ? `0 0 4px ${C.green}80` : `0 0 4px #ef444480`,
+      transform: "translateY(0.5px)",
+    }} />
+  );
+}
+
+/* ── Role badge color ── */
+function roleBadgeColor(role: string): string {
+  if (role === "LEADER") return C.accent;
+  if (role === "OBSERVER") return C.warning;
+  return C.text2;
+}
+
+/* ── FE Node card — resource metrics come from /metrics endpoint ── */
+function FENodeCard({ node, expanded, onToggle }: { node: FENodeInfo; expanded: boolean; onToggle: () => void }) {
+  const hasMetrics = node.jvm_heap_used_pct != null;
+  const displayName = shortenNodeName(node.name);
+  const displayIp = shortenNodeName(node.ip);
+
+  return (
+    <div style={{ border: `1px solid ${node.alive ? C.borderLight : "#ef4444"}`, borderRadius: 6, marginBottom: 6, overflow: "hidden", background: C.card }}>
+      {/* Header row — clickable */}
+      <div
+        onClick={onToggle}
+        style={{
+          display: "flex", alignItems: "center", gap: 8, padding: "8px 12px",
+          cursor: "pointer", userSelect: "none",
+          background: expanded ? "rgba(59,130,246,0.06)" : "transparent",
+        }}
+      >
+        <StatusDot alive={node.alive} />
+        <span
+          title={node.name}
+          style={{ fontSize: 13, fontWeight: 600, color: C.text1, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+        >
+          {displayName}
+        </span>
+        {displayIp !== displayName && (
+          <span title={node.ip} style={{ fontSize: 12, color: C.text2, flexShrink: 0 }}>{displayIp}</span>
+        )}
+        <Badge text={node.role} color={roleBadgeColor(node.role)} />
+        <Badge text={node.alive ? "ALIVE" : "DEAD"} color={node.alive ? C.green : "#ef4444"} />
+        <span style={{ fontSize: 10, color: C.text3, marginLeft: 2 }}>{expanded ? "▲" : "▼"}</span>
+      </div>
+
+      {/* Resource bars — Heap usage (from /metrics) */}
+      {(hasMetrics || node.metrics_error) && (
+        <div style={{ padding: "4px 12px 8px" }}>
+          {hasMetrics ? (
+            <MetricRow label="Heap" pct={node.jvm_heap_used_pct ?? 0} />
+          ) : (
+            <div
+              style={{
+                fontSize: 11,
+                color: C.text3,
+                padding: "4px 8px",
+                background: "rgba(148,163,184,0.08)",
+                borderRadius: 4,
+                fontStyle: "italic",
+              }}
+              title={node.metrics_error ?? ""}
+            >
+              Metrics unavailable ({node.metrics_error})
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Expanded details */}
+      {expanded && (
+        <div style={{ padding: "8px 12px 10px", borderTop: `1px solid ${C.border}`, display: "grid", gridTemplateColumns: "1fr 1fr", gap: "6px 16px" }}>
+          {node.version && <Detail label="Version" value={node.version} />}
+          {node.replayed_journal_id != null && <Detail label="Journal ID" value={node.replayed_journal_id.toLocaleString()} />}
+          {node.start_time && <Detail label="Start Time" value={formatRelativeTime(node.start_time)} />}
+          {node.gc_young_count != null && (
+            <Detail
+              label="Young GC (cumulative)"
+              value={`${node.gc_young_count.toLocaleString()} times${node.gc_young_time_ms != null ? ` · ${(node.gc_young_time_ms / 1000).toFixed(1)}s` : ""}`}
+            />
+          )}
+          {node.gc_old_count != null && (
+            <Detail
+              label="Old GC (cumulative)"
+              value={`${node.gc_old_count.toLocaleString()} times${node.gc_old_time_ms != null ? ` · ${(node.gc_old_time_ms / 1000).toFixed(1)}s` : ""}`}
+            />
+          )}
+          {node.query_p99_ms != null && (
+            <Detail label="Query p99" value={`${node.query_p99_ms.toFixed(1)} ms`} />
+          )}
+          {node.err_msg && (
+            <div style={{ gridColumn: "1 / -1", color: "#ef4444", fontSize: 12, marginTop: 4, padding: "4px 8px", background: "rgba(239,68,68,0.08)", borderRadius: 4 }}>
+              {node.err_msg}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── BE/CN Node card — branches on node_type, resource-focused ── */
+function BENodeCard({ node, expanded, onToggle }: { node: BENodeInfo; expanded: boolean; onToggle: () => void }) {
+  const isCompute = node.node_type === "compute";
+  const diskPct = node.used_pct ?? 0;
+  const diskLabel =
+    node.data_used_capacity && node.total_capacity
+      ? `${node.data_used_capacity} / ${node.total_capacity}`
+      : null;
+
+  return (
+    <div style={{ border: `1px solid ${node.alive ? C.borderLight : "#ef4444"}`, borderRadius: 6, marginBottom: 6, overflow: "hidden", background: C.card }}>
+      {/* Header row — clickable */}
+      <div
+        onClick={onToggle}
+        style={{
+          display: "flex", alignItems: "center", gap: 8, padding: "8px 12px",
+          cursor: "pointer", userSelect: "none",
+          background: expanded ? "rgba(59,130,246,0.06)" : "transparent",
+        }}
+      >
+        <StatusDot alive={node.alive} />
+        {(() => {
+          const dn = shortenNodeName(node.name);
+          const di = shortenNodeName(node.ip);
+          return (
+            <>
+              <span
+                title={node.name}
+                style={{ fontSize: 13, fontWeight: 600, color: C.text1, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+              >
+                {dn}
+              </span>
+              {di !== dn && (
+                <span title={node.ip} style={{ fontSize: 12, color: C.text2, flexShrink: 0 }}>{di}</span>
+              )}
+            </>
+          );
+        })()}
+        <Badge text={isCompute ? "CN" : "BE"} color={isCompute ? C.warning : C.accent} />
+        <Badge text={node.alive ? "ALIVE" : "DEAD"} color={node.alive ? C.green : "#ef4444"} />
+        <span style={{ fontSize: 10, color: C.text3, marginLeft: 2 }}>{expanded ? "▲" : "▼"}</span>
+      </div>
+
+      {/* Resource bars — always visible */}
+      <div style={{ padding: "4px 12px 8px" }}>
+        {node.tablet_count != null && (
+          <div style={{ fontSize: 11, color: C.text3, marginBottom: 4 }}>
+            {node.tablet_count.toLocaleString()} tablets
+          </div>
+        )}
+        {/* Disk (BE: persistent) / Disk Cache (CN: local cache) */}
+        {diskLabel != null && node.used_pct != null && (
+          <MetricRow
+            label={isCompute ? "Disk Cache" : "Disk"}
+            pct={diskPct}
+            extra={diskLabel}
+          />
+        )}
+
+        {/* CPU (CN only — SHOW BACKENDS does not report CPU %) */}
+        {isCompute && node.cpu_used_pct != null && (
+          <MetricRow
+            label="CPU"
+            pct={node.cpu_used_pct}
+            extra={node.cpu_cores != null ? `${node.cpu_cores} cores` : undefined}
+          />
+        )}
+
+        {/* Memory (both BE and CN) */}
+        {node.mem_used_pct != null && (
+          <MetricRow
+            label="Memory"
+            pct={node.mem_used_pct}
+            extra={node.mem_limit ? `of ${node.mem_limit}` : undefined}
+          />
+        )}
+      </div>
+
+      {/* Expanded details — identity / activity only; no ports */}
+      {expanded && (
+        <div style={{ padding: "8px 12px 10px", borderTop: `1px solid ${C.border}`, display: "grid", gridTemplateColumns: "1fr 1fr", gap: "6px 16px" }}>
+          {isCompute && node.warehouse && <Detail label="Warehouse" value={node.warehouse} />}
+          {!isCompute && node.cpu_cores != null && <Detail label="CPU Cores" value={String(node.cpu_cores)} />}
+          {node.num_running_queries != null && <Detail label="Running Queries" value={String(node.num_running_queries)} />}
+          {node.last_start_time && <Detail label="Last Start" value={formatRelativeTime(node.last_start_time)} />}
+          {node.version && <Detail label="Version" value={node.version} />}
+          {node.err_msg && (
+            <div style={{ gridColumn: "1 / -1", color: "#ef4444", fontSize: 12, marginTop: 4, padding: "4px 8px", background: "rgba(239,68,68,0.08)", borderRadius: 4 }}>
+              {node.err_msg}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Key-value detail row ── */
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div style={{ fontSize: 10, color: C.text3, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 1 }}>{label}</div>
+      <div style={{ fontSize: 12, color: C.text1, fontWeight: 500, wordBreak: "break-all" }}>{value}</div>
+    </div>
+  );
+}
+
+/* ── Section header ── */
+function SectionHeader({ title, count }: { title: string; count: number }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 0 6px", borderBottom: `1px solid ${C.border}`, marginBottom: 8 }}>
+      <span style={{ fontSize: 13, fontWeight: 700, color: C.text1 }}>{title}</span>
+      <span style={{ fontSize: 11, color: C.text3 }}>({count})</span>
+    </div>
+  );
+}
+
+/* ── Main ClusterDrawer ── */
+export default function ClusterDrawer() {
+  const { isOpen, closeDrawer, expandedNodes, toggleNodeExpansion } = useClusterStore();
+  const [data, setData] = useState<ClusterStatusResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchData = useCallback(() => {
+    // Cancel any in-flight request
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    setError(null);
+
+    getClusterStatus(controller.signal)
+      .then((res) => {
+        setData(res);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        const msg = err instanceof Error ? err.message : "Unknown error";
+        setError(msg);
+        setLoading(false);
+      });
+  }, []);
+
+  // Fetch on open
+  useEffect(() => {
+    if (isOpen) {
+      fetchData();
+    } else {
+      // Cancel any in-flight request when closed
+      abortRef.current?.abort();
+      abortRef.current = null;
+    }
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, [isOpen, fetchData]);
+
+  // ESC key handler
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeDrawer();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, closeDrawer]);
+
+  const metrics = data?.metrics;
+  const frontends = data?.frontends ?? [];
+  const backends = data?.backends ?? [];
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        onClick={closeDrawer}
+        style={{
+          position: "fixed", inset: 0, background: "rgba(0,0,0,0.3)",
+          zIndex: 49,
+          opacity: isOpen ? 1 : 0,
+          pointerEvents: isOpen ? "auto" : "none",
+          transition: "opacity 200ms",
+        }}
+      />
+
+      {/* Drawer panel */}
+      <div
+        style={{
+          position: "fixed", top: 0, right: 0, bottom: 0,
+          width: 440, zIndex: 50,
+          background: C.bg,
+          borderLeft: `1px solid ${C.borderLight}`,
+          display: "flex", flexDirection: "column",
+          transform: isOpen ? "translateX(0)" : "translateX(100%)",
+          transition: "transform 200ms ease",
+          overflowY: "auto",
+        }}
+      >
+        {/* ── Header bar ── */}
+        <div style={{
+          display: "flex", alignItems: "center", gap: 8, padding: "0 16px",
+          height: 56, borderBottom: `1px solid ${C.borderLight}`, flexShrink: 0,
+          background: C.card,
+        }}>
+          <svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke={C.accent} strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="4" width="18" height="6" rx="1"/>
+            <rect x="3" y="14" width="18" height="6" rx="1"/>
+            <line x1="6" y1="7" x2="6.01" y2="7"/>
+            <line x1="6" y1="17" x2="6.01" y2="17"/>
+          </svg>
+          <span style={{ fontSize: 15, fontWeight: 700, color: C.text1, flex: 1 }}>Cluster Status</span>
+
+          {/* Refresh button */}
+          <button
+            onClick={fetchData}
+            disabled={loading}
+            title="Refresh"
+            style={{
+              width: 32, height: 32, border: `1px solid ${C.borderLight}`, borderRadius: 6,
+              background: "transparent", color: C.text2, cursor: loading ? "not-allowed" : "pointer",
+              display: "flex", alignItems: "center", justifyContent: "center", fontSize: 15,
+              opacity: loading ? 0.5 : 1, fontFamily: "inherit",
+            }}
+            onMouseEnter={(e) => { if (!loading) e.currentTarget.style.color = C.accent; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = C.text2; }}
+          >
+            ↻
+          </button>
+
+          {/* Close button */}
+          <button
+            onClick={closeDrawer}
+            title="Close"
+            style={{
+              width: 32, height: 32, border: `1px solid ${C.borderLight}`, borderRadius: 6,
+              background: "transparent", color: C.text2, cursor: "pointer",
+              display: "flex", alignItems: "center", justifyContent: "center", fontSize: 18,
+              fontFamily: "inherit",
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = "#ef4444"; e.currentTarget.style.borderColor = "#ef4444"; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = C.text2; e.currentTarget.style.borderColor = C.borderLight; }}
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* ── Scrollable body ── */}
+        <div style={{ flex: 1, overflowY: "auto", padding: 16 }}>
+
+          {/* Loading state */}
+          {loading && <Loader />}
+
+          {/* Error state (network / 5xx) */}
+          {!loading && error && (
+            <div style={{
+              padding: 12, borderRadius: 6, border: `1px solid ${C.borderLight}`,
+              background: "rgba(239,68,68,0.06)", fontSize: 12, color: C.text2, textAlign: "center",
+            }}>
+              Failed to load cluster status.{" "}
+              <button
+                onClick={fetchData}
+                style={{ background: "none", border: "none", color: C.accent, cursor: "pointer", fontSize: 12, padding: 0, fontFamily: "inherit" }}
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
+          {/* Data content */}
+          {!loading && data && (
+            <>
+              {/* Limited-mode banner (cluster_admin not granted) */}
+              {data.mode === "limited" && (
+                <div style={{
+                  padding: 10, marginBottom: 12, borderRadius: 6,
+                  border: `1px solid ${C.accent}40`,
+                  background: `${C.accent}12`,
+                  fontSize: 12, color: C.text1, display: "flex", gap: 8, alignItems: "flex-start",
+                }}>
+                  <span style={{ fontSize: 14 }}>ℹ️</span>
+                  <span>
+                    <strong>Limited view</strong> — showing only the FE you're connected to.
+                    Full cluster inventory requires the <code style={{ color: C.accent }}>cluster_admin</code> role.
+                  </span>
+                </div>
+              )}
+
+              {/* Metrics warning banner (all /metrics probes failed) */}
+              {data.metrics_warning && (
+                <div style={{
+                  padding: 10, marginBottom: 12, borderRadius: 6,
+                  border: `1px solid ${C.warning}40`,
+                  background: `${C.warning}12`,
+                  fontSize: 12, color: C.text1, display: "flex", gap: 8, alignItems: "flex-start",
+                }}>
+                  <span style={{ fontSize: 14 }}>⚠️</span>
+                  <span>{data.metrics_warning}</span>
+                </div>
+              )}
+
+              {/* ── Summary card ── */}
+              <div style={{
+                background: C.card, border: `1px solid ${C.borderLight}`, borderRadius: 8,
+                padding: 14, marginBottom: 14,
+              }}>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px 16px" }}>
+                  {/* FE alive */}
+                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <StatusDot alive={metrics!.fe_alive === metrics!.fe_total} />
+                    <span style={{ fontSize: 13, color: C.text1 }}>
+                      FE <strong>{metrics!.fe_alive}/{metrics!.fe_total}</strong> alive
+                    </span>
+                  </div>
+                  {/* BE alive (only if any BE exists) */}
+                  {metrics!.be_total > 0 && (
+                    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                      <StatusDot alive={metrics!.be_alive === metrics!.be_total} />
+                      <span style={{ fontSize: 13, color: C.text1 }}>
+                        BE <strong>{metrics!.be_alive}/{metrics!.be_total}</strong> alive
+                      </span>
+                    </div>
+                  )}
+                  {/* CN alive (only if any CN exists) */}
+                  {metrics!.cn_total > 0 && (
+                    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                      <StatusDot alive={metrics!.cn_alive === metrics!.cn_total} />
+                      <span style={{ fontSize: 13, color: C.text1 }}>
+                        CN <strong>{metrics!.cn_alive}/{metrics!.cn_total}</strong> alive
+                      </span>
+                    </div>
+                  )}
+                  {/* Tablets */}
+                  {metrics!.total_tablets != null && (
+                    <div style={{ fontSize: 12, color: C.text2 }}>
+                      <span style={{ color: C.text3 }}>Tablets: </span>
+                      <strong style={{ color: C.text1 }}>{metrics!.total_tablets.toLocaleString()}</strong>
+                    </div>
+                  )}
+                  {/* Data used (BE only) */}
+                  {metrics!.total_data_used && (
+                    <div style={{ fontSize: 12, color: C.text2 }}>
+                      <span style={{ color: C.text3 }}>Data Used: </span>
+                      <strong style={{ color: C.text1 }}>{metrics!.total_data_used}</strong>
+                    </div>
+                  )}
+                  {/* Avg Disk/Cache — label depends on cluster shape */}
+                  {metrics!.avg_disk_used_pct != null && (
+                    <div style={{ fontSize: 12, color: C.text2 }}>
+                      <span style={{ color: C.text3 }}>
+                        {metrics!.be_total > 0 && metrics!.cn_total > 0
+                          ? "Avg Disk/Cache: "
+                          : metrics!.be_total > 0
+                            ? "Avg Disk: "
+                            : "Avg Cache: "}
+                      </span>
+                      <strong style={{ color: C.text1 }}>{metrics!.avg_disk_used_pct.toFixed(1)}%</strong>
+                    </div>
+                  )}
+                  {/* Avg CPU (CN only) */}
+                  {metrics!.avg_cpu_used_pct != null && (
+                    <div style={{ fontSize: 12, color: C.text2 }}>
+                      <span style={{ color: C.text3 }}>Avg CPU: </span>
+                      <strong style={{ color: C.text1 }}>{metrics!.avg_cpu_used_pct.toFixed(1)}%</strong>
+                    </div>
+                  )}
+                  {/* Avg Mem */}
+                  {metrics!.avg_mem_used_pct != null && (
+                    <div style={{ fontSize: 12, color: C.text2 }}>
+                      <span style={{ color: C.text3 }}>Avg Mem: </span>
+                      <strong style={{ color: C.text1 }}>{metrics!.avg_mem_used_pct.toFixed(1)}%</strong>
+                    </div>
+                  )}
+                  {/* Avg FE Heap (from /metrics) */}
+                  {metrics!.avg_fe_heap_used_pct != null && (
+                    <div style={{ fontSize: 12, color: C.text2 }}>
+                      <span style={{ color: C.text3 }}>Avg FE Heap: </span>
+                      <strong style={{ color: C.text1 }}>{metrics!.avg_fe_heap_used_pct.toFixed(1)}%</strong>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* ── Alerts section ── */}
+              {data.has_errors && (
+                <div style={{ marginBottom: 14 }}>
+                  <div style={{ fontSize: 12, fontWeight: 700, color: "#ef4444", marginBottom: 6, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>⚠</span>
+                    <span>Alerts</span>
+                    <span style={{ color: C.text3, fontWeight: 400 }}>
+                      ({[...frontends, ...backends].filter((n) => !n.alive || n.err_msg).length})
+                    </span>
+                  </div>
+                  {[
+                    ...frontends.filter((n) => !n.alive || n.err_msg).map((n) => ({ name: shortenNodeName(n.name), full: n.name, ip: n.ip, msg: n.err_msg || "Node is DEAD" })),
+                    ...backends.filter((n) => !n.alive || n.err_msg).map((n) => ({ name: shortenNodeName(n.name), full: n.name, ip: n.ip, msg: n.err_msg || "Node is DEAD" })),
+                  ].map((alert) => (
+                    <div key={`${alert.full}:${alert.ip}`} style={{
+                      display: "flex", alignItems: "center", gap: 8, padding: "6px 10px",
+                      borderRadius: 4, border: "1px solid rgba(239,68,68,0.3)",
+                      background: "rgba(239,68,68,0.06)", marginBottom: 4, fontSize: 12,
+                    }}>
+                      <span title={alert.full} style={{ fontWeight: 600, color: "#ef4444" }}>{alert.name}</span>
+                      <span style={{ color: C.text3 }}>{alert.ip}</span>
+                      <span style={{ color: C.text2, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{alert.msg}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* ── Frontend Nodes ── */}
+              <SectionHeader title="Frontend Nodes" count={frontends.length} />
+              {frontends.length === 0 ? (
+                <div style={{ fontSize: 12, color: C.text3, padding: "8px 0" }}>No nodes reported</div>
+              ) : (
+                frontends.map((node) => {
+                  const id = `fe:${node.name}`;
+                  return (
+                    <FENodeCard
+                      key={id}
+                      node={node}
+                      expanded={expandedNodes.has(id)}
+                      onToggle={() => toggleNodeExpansion(id)}
+                    />
+                  );
+                })
+              )}
+
+              {/* ── Backend / Compute Nodes ── */}
+              <div style={{ marginTop: 8 }}>
+                <SectionHeader
+                  title={
+                    metrics!.be_total > 0 && metrics!.cn_total > 0
+                      ? "Backend & Compute Nodes"
+                      : metrics!.cn_total > 0
+                        ? "Compute Nodes"
+                        : "Backend Nodes"
+                  }
+                  count={backends.length}
+                />
+                {backends.length === 0 ? (
+                  <div style={{ fontSize: 12, color: C.text3, padding: "8px 0" }}>No nodes reported</div>
+                ) : (
+                  backends.map((node) => {
+                    const id = `${node.node_type === "compute" ? "cn" : "be"}:${node.name}`;
+                    return (
+                      <BENodeCard
+                        key={id}
+                        node={node}
+                        expanded={expandedNodes.has(id)}
+                        onToggle={() => toggleNodeExpansion(id)}
+                      />
+                    );
+                  })
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/cluster/ClusterDrawer.tsx
+++ b/frontend/src/components/cluster/ClusterDrawer.tsx
@@ -149,6 +149,8 @@ function BENodeCard({ node, expanded, onToggle }: { node: BENodeInfo; expanded: 
     node.data_used_capacity && node.total_capacity
       ? `${node.data_used_capacity} / ${node.total_capacity}`
       : null;
+  const displayName = shortenNodeName(node.name);
+  const displayIp = shortenNodeName(node.ip);
 
   return (
     <div style={{ border: `1px solid ${node.alive ? C.borderLight : "#ef4444"}`, borderRadius: 6, marginBottom: 6, overflow: "hidden", background: C.card }}>
@@ -162,23 +164,15 @@ function BENodeCard({ node, expanded, onToggle }: { node: BENodeInfo; expanded: 
         }}
       >
         <StatusDot alive={node.alive} />
-        {(() => {
-          const dn = shortenNodeName(node.name);
-          const di = shortenNodeName(node.ip);
-          return (
-            <>
-              <span
-                title={node.name}
-                style={{ fontSize: 13, fontWeight: 600, color: C.text1, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
-              >
-                {dn}
-              </span>
-              {di !== dn && (
-                <span title={node.ip} style={{ fontSize: 12, color: C.text2, flexShrink: 0 }}>{di}</span>
-              )}
-            </>
-          );
-        })()}
+        <span
+          title={node.name}
+          style={{ fontSize: 13, fontWeight: 600, color: C.text1, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+        >
+          {displayName}
+        </span>
+        {displayIp !== displayName && (
+          <span title={node.ip} style={{ fontSize: 12, color: C.text2, flexShrink: 0 }}>{displayIp}</span>
+        )}
         <Badge text={isCompute ? "CN" : "BE"} color={isCompute ? C.warning : C.accent} />
         <Badge text={node.alive ? "ALIVE" : "DEAD"} color={node.alive ? C.green : "#ef4444"} />
         <span style={{ fontSize: 10, color: C.text3, marginLeft: 2 }}>{expanded ? "▲" : "▼"}</span>

--- a/frontend/src/components/common/InlineIcon.tsx
+++ b/frontend/src/components/common/InlineIcon.tsx
@@ -1,7 +1,7 @@
 import { colorizedSvg } from "../dag/nodeIcons";
 
-export default function InlineIcon({ type, size = 14 }: { type: string; size?: number }) {
-  const svg = colorizedSvg(type);
+export default function InlineIcon({ type, size = 14, color }: { type: string; size?: number; color?: string }) {
+  const svg = colorizedSvg(type, color);
   if (!svg) return null;
   const sized = svg.replace(/width="[^"]*"/, `width="${size}"`).replace(/height="[^"]*"/, `height="${size}"`);
   return <span style={{ width: size, height: size, flexShrink: 0, display: "inline-flex", alignItems: "center", verticalAlign: "middle" }} dangerouslySetInnerHTML={{ __html: sized }} />;

--- a/frontend/src/components/dag/nodeIcons.ts
+++ b/frontend/src/components/dag/nodeIcons.ts
@@ -14,6 +14,10 @@ import functionIcon from "../../../icons/function.svg?raw";
 import userIcon from "../../../icons/user.svg?raw";
 import roleIcon from "../../../icons/role.svg?raw";
 import appLogoRaw from "../../../icons/app-logo.svg?raw";
+import infoIcon from "../../../icons/info.svg?raw";
+import warningIcon from "../../../icons/warning.svg?raw";
+import refreshIcon from "../../../icons/refresh.svg?raw";
+import closeIcon from "../../../icons/close.svg?raw";
 
 // Raw SVG strings for inline rendering
 export const NODE_SVG_RAW: Record<string, string> = {
@@ -26,6 +30,10 @@ export const NODE_SVG_RAW: Record<string, string> = {
   function: functionIcon,
   user: userIcon,
   role: roleIcon,
+  info: infoIcon,
+  warning: warningIcon,
+  refresh: refreshIcon,
+  close: closeIcon,
 };
 
 export const APP_LOGO_SVG = appLogoRaw;
@@ -40,6 +48,10 @@ export const NODE_COLORS: Record<string, string> = {
   function: "#14b8a6",
   user: "#0ea5e9",
   role: "#f97316",
+  info: "#3b82f6",
+  warning: "#f59e0b",
+  refresh: "#94a3b8",
+  close: "#94a3b8",
 };
 
 /** Role sub-type colors — used when backend sends metadata.role_category */

--- a/frontend/src/components/layout/Header.test.tsx
+++ b/frontend/src/components/layout/Header.test.tsx
@@ -95,4 +95,22 @@ describe("Header", () => {
     await user.click(screen.getByTestId("cluster-status-btn"));
     expect(useClusterStore.getState().isOpen).toBe(true);
   });
+
+  it("cluster status button hover updates color style", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    const btn = screen.getByTestId("cluster-status-btn");
+    await user.hover(btn);
+    await user.unhover(btn);
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("logout button hover/unhover does not throw", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    const logoutBtn = screen.getByText("Logout");
+    await user.hover(logoutBtn);
+    await user.unhover(logoutBtn);
+    expect(logoutBtn).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/layout/Header.test.tsx
+++ b/frontend/src/components/layout/Header.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "../../test/test-utils";
 import userEvent from "@testing-library/user-event";
 import Header from "./Header";
+import { useClusterStore } from "../../stores/clusterStore";
 
 // Mock nodeIcons to avoid SVG ?raw imports
 vi.mock("../dag/nodeIcons", () => ({
@@ -33,6 +34,8 @@ vi.mock("../../stores/authStore", () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Reset cluster store state before each test
+  useClusterStore.setState({ isOpen: false });
 });
 
 describe("Header", () => {
@@ -76,5 +79,20 @@ describe("Header", () => {
     expect(screen.getByText("viewer")).toBeInTheDocument();
     // No @host:port text
     expect(screen.queryByText(/@/)).not.toBeInTheDocument();
+  });
+
+  it("renders cluster status icon button", () => {
+    render(<Header />);
+    const btn = screen.getByTestId("cluster-status-btn");
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute("aria-label", "Cluster Status");
+  });
+
+  it("clicking cluster status button toggles drawer open", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    expect(useClusterStore.getState().isOpen).toBe(false);
+    await user.click(screen.getByTestId("cluster-status-btn"));
+    expect(useClusterStore.getState().isOpen).toBe(true);
   });
 });

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,9 +1,11 @@
 import { useAuthStore } from "../../stores/authStore";
 import { APP_LOGO_SVG } from "../dag/nodeIcons";
 import { C } from "../../utils/colors";
+import { useClusterStore } from "../../stores/clusterStore";
 
 export default function Header() {
   const { user, connectionInfo, logout } = useAuthStore();
+  const toggleDrawer = useClusterStore((s) => s.toggleDrawer);
 
   return (
     <header style={{
@@ -25,6 +27,27 @@ export default function Header() {
           <strong style={{ color: C.text1 }}>{user?.username}</strong>
           {connectionInfo && `@${connectionInfo.host}:${connectionInfo.port}`}
         </span>
+        <button
+          onClick={toggleDrawer}
+          aria-label="Cluster Status"
+          title="Cluster Status"
+          data-testid="cluster-status-btn"
+          style={{
+            width: 34, height: 34, padding: 0,
+            background: "transparent", border: `1px solid ${C.borderLight}`,
+            borderRadius: 6, color: C.text2, cursor: "pointer",
+            display: "flex", alignItems: "center", justifyContent: "center",
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.color = C.accent; e.currentTarget.style.borderColor = C.accent; }}
+          onMouseLeave={(e) => { e.currentTarget.style.color = C.text2; e.currentTarget.style.borderColor = C.borderLight; }}
+        >
+          <svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="4" width="18" height="6" rx="1"/>
+            <rect x="3" y="14" width="18" height="6" rx="1"/>
+            <line x1="6" y1="7" x2="6.01" y2="7"/>
+            <line x1="6" y1="17" x2="6.01" y2="17"/>
+          </svg>
+        </button>
         <button
           onClick={logout}
           style={{

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -130,5 +130,51 @@ describe("useAuthStore", () => {
       useAuthStore.getState().setConnectionInfo("host2", 9031);
       expect(useAuthStore.getState().connectionInfo).toEqual({ host: "host2", port: 9031 });
     });
+
+    it("persists connection info to localStorage", () => {
+      useAuthStore.getState().setConnectionInfo("sr-host", 9030);
+      const raw = localStorage.getItem("sr_connection");
+      expect(raw).not.toBeNull();
+      const parsed = JSON.parse(raw!);
+      expect(parsed).toEqual({ host: "sr-host", port: 9030 });
+    });
+  });
+
+  describe("loadConnectionInfo (cold start)", () => {
+    it("loads valid connection info from localStorage on cold start", async () => {
+      localStorage.setItem("sr_connection", JSON.stringify({ host: "10.1.2.3", port: 9030 }));
+
+      vi.resetModules();
+      const { useAuthStore: freshStore } = await import("./authStore");
+
+      expect(freshStore.getState().connectionInfo).toEqual({ host: "10.1.2.3", port: 9030 });
+    });
+
+    it("returns null for malformed JSON in sr_connection", async () => {
+      localStorage.setItem("sr_connection", "not-valid-json{{{");
+
+      vi.resetModules();
+      const { useAuthStore: freshStore } = await import("./authStore");
+
+      expect(freshStore.getState().connectionInfo).toBeNull();
+    });
+
+    it("returns null when sr_connection has wrong field types", async () => {
+      localStorage.setItem("sr_connection", JSON.stringify({ host: 12345, port: "9030" }));
+
+      vi.resetModules();
+      const { useAuthStore: freshStore } = await import("./authStore");
+
+      expect(freshStore.getState().connectionInfo).toBeNull();
+    });
+
+    it("returns null when sr_connection is absent", async () => {
+      localStorage.removeItem("sr_connection");
+
+      vi.resetModules();
+      const { useAuthStore: freshStore } = await import("./authStore");
+
+      expect(freshStore.getState().connectionInfo).toBeNull();
+    });
   });
 });

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -12,11 +12,23 @@ interface AuthState {
   setConnectionInfo: (host: string, port: number) => void;
 }
 
+function loadConnectionInfo(): { host: string; port: number } | null {
+  try {
+    const raw = localStorage.getItem("sr_connection");
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { host?: unknown; port?: unknown };
+    if (typeof parsed.host === "string" && typeof parsed.port === "number") {
+      return { host: parsed.host, port: parsed.port };
+    }
+  } catch { /* ignore malformed storage */ }
+  return null;
+}
+
 export const useAuthStore = create<AuthState>((set) => ({
   token: localStorage.getItem("sr_token"),
   user: null,
   isLoggedIn: !!localStorage.getItem("sr_token"),
-  connectionInfo: null,
+  connectionInfo: loadConnectionInfo(),
   setAuth: (token, user) => {
     localStorage.setItem("sr_token", token);
     set({ token, user, isLoggedIn: true });
@@ -24,7 +36,11 @@ export const useAuthStore = create<AuthState>((set) => ({
   logout: () => {
     logoutApi().catch(() => {});
     localStorage.removeItem("sr_token");
+    localStorage.removeItem("sr_connection");
     set({ token: null, user: null, isLoggedIn: false, connectionInfo: null });
   },
-  setConnectionInfo: (host, port) => set({ connectionInfo: { host, port } }),
+  setConnectionInfo: (host, port) => {
+    localStorage.setItem("sr_connection", JSON.stringify({ host, port }));
+    set({ connectionInfo: { host, port } });
+  },
 }));

--- a/frontend/src/stores/clusterStore.test.ts
+++ b/frontend/src/stores/clusterStore.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useClusterStore } from "./clusterStore";
+
+beforeEach(() => {
+  useClusterStore.setState({
+    isOpen: false,
+    expandedNodes: new Set<string>(),
+  });
+});
+
+describe("useClusterStore", () => {
+  describe("initial state", () => {
+    it("defaults isOpen to false", () => {
+      expect(useClusterStore.getState().isOpen).toBe(false);
+    });
+
+    it("defaults expandedNodes to empty Set", () => {
+      expect(useClusterStore.getState().expandedNodes.size).toBe(0);
+    });
+  });
+
+  describe("openDrawer", () => {
+    it("sets isOpen to true", () => {
+      useClusterStore.getState().openDrawer();
+      expect(useClusterStore.getState().isOpen).toBe(true);
+    });
+
+    it("keeps isOpen true when called again", () => {
+      useClusterStore.getState().openDrawer();
+      useClusterStore.getState().openDrawer();
+      expect(useClusterStore.getState().isOpen).toBe(true);
+    });
+  });
+
+  describe("closeDrawer", () => {
+    it("sets isOpen to false", () => {
+      useClusterStore.getState().openDrawer();
+      useClusterStore.getState().closeDrawer();
+      expect(useClusterStore.getState().isOpen).toBe(false);
+    });
+
+    it("keeps isOpen false when already closed", () => {
+      useClusterStore.getState().closeDrawer();
+      expect(useClusterStore.getState().isOpen).toBe(false);
+    });
+  });
+
+  describe("toggleDrawer", () => {
+    it("opens when closed", () => {
+      useClusterStore.getState().toggleDrawer();
+      expect(useClusterStore.getState().isOpen).toBe(true);
+    });
+
+    it("closes when open", () => {
+      useClusterStore.getState().openDrawer();
+      useClusterStore.getState().toggleDrawer();
+      expect(useClusterStore.getState().isOpen).toBe(false);
+    });
+
+    it("toggles back and forth correctly", () => {
+      useClusterStore.getState().toggleDrawer();
+      expect(useClusterStore.getState().isOpen).toBe(true);
+      useClusterStore.getState().toggleDrawer();
+      expect(useClusterStore.getState().isOpen).toBe(false);
+      useClusterStore.getState().toggleDrawer();
+      expect(useClusterStore.getState().isOpen).toBe(true);
+    });
+  });
+
+  describe("toggleNodeExpansion", () => {
+    it("adds a node id to expandedNodes", () => {
+      useClusterStore.getState().toggleNodeExpansion("fe-01");
+      expect(useClusterStore.getState().expandedNodes.has("fe-01")).toBe(true);
+    });
+
+    it("removes a node id if already expanded", () => {
+      useClusterStore.getState().toggleNodeExpansion("fe-01");
+      useClusterStore.getState().toggleNodeExpansion("fe-01");
+      expect(useClusterStore.getState().expandedNodes.has("fe-01")).toBe(false);
+    });
+
+    it("handles multiple nodes independently", () => {
+      useClusterStore.getState().toggleNodeExpansion("fe-01");
+      useClusterStore.getState().toggleNodeExpansion("be-01");
+      expect(useClusterStore.getState().expandedNodes.size).toBe(2);
+      useClusterStore.getState().toggleNodeExpansion("fe-01");
+      expect(useClusterStore.getState().expandedNodes.has("fe-01")).toBe(false);
+      expect(useClusterStore.getState().expandedNodes.has("be-01")).toBe(true);
+    });
+
+    it("can expand multiple distinct nodes", () => {
+      useClusterStore.getState().toggleNodeExpansion("fe-01");
+      useClusterStore.getState().toggleNodeExpansion("fe-02");
+      useClusterStore.getState().toggleNodeExpansion("be-01");
+      expect(useClusterStore.getState().expandedNodes.size).toBe(3);
+    });
+  });
+
+  describe("collapseAll", () => {
+    it("resets expandedNodes to empty Set", () => {
+      useClusterStore.getState().toggleNodeExpansion("fe-01");
+      useClusterStore.getState().toggleNodeExpansion("be-01");
+      expect(useClusterStore.getState().expandedNodes.size).toBe(2);
+
+      useClusterStore.getState().collapseAll();
+      expect(useClusterStore.getState().expandedNodes.size).toBe(0);
+    });
+
+    it("is a no-op when already empty", () => {
+      useClusterStore.getState().collapseAll();
+      expect(useClusterStore.getState().expandedNodes.size).toBe(0);
+    });
+  });
+});

--- a/frontend/src/stores/clusterStore.ts
+++ b/frontend/src/stores/clusterStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+interface ClusterState {
+  isOpen: boolean;
+  openDrawer: () => void;
+  closeDrawer: () => void;
+  toggleDrawer: () => void;
+  expandedNodes: Set<string>;
+  toggleNodeExpansion: (id: string) => void;
+  collapseAll: () => void;
+}
+
+export const useClusterStore = create<ClusterState>((set) => ({
+  isOpen: false,
+  openDrawer: () => set({ isOpen: true }),
+  closeDrawer: () => set({ isOpen: false }),
+  toggleDrawer: () => set((s) => ({ isOpen: !s.isOpen })),
+  expandedNodes: new Set<string>(),
+  toggleNodeExpansion: (id) =>
+    set((s) => {
+      const next = new Set(s.expandedNodes);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return { expandedNodes: next };
+    }),
+  collapseAll: () => set({ expandedNodes: new Set<string>() }),
+}));

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -105,3 +105,78 @@ export interface TableDetail {
   storage_medium: string | null;
   compression: string | null;
 }
+
+// ── Cluster Status ──
+export interface FENodeInfo {
+  name: string;
+  ip: string;
+  edit_log_port: number | null;
+  http_port: number | null;
+  query_port: number | null;
+  rpc_port: number | null;
+  role: string;
+  alive: boolean;
+  join: boolean;
+  last_heartbeat: string | null;
+  replayed_journal_id: number | null;
+  start_time: string | null;
+  version: string | null;
+  err_msg: string | null;
+  // Populated from FE /metrics endpoint
+  jvm_heap_used_pct: number | null;
+  gc_young_count: number | null;
+  gc_young_time_ms: number | null;
+  gc_old_count: number | null;
+  gc_old_time_ms: number | null;
+  query_p99_ms: number | null;
+  metrics_error: string | null;
+}
+
+export interface BENodeInfo {
+  name: string;
+  ip: string;
+  node_type: "backend" | "compute";
+  heartbeat_port: number | null;
+  be_port: number | null;
+  http_port: number | null;
+  brpc_port: number | null;
+  alive: boolean;
+  last_heartbeat: string | null;
+  last_start_time: string | null;
+  tablet_count: number | null;
+  data_used_capacity: string | null;
+  total_capacity: string | null;
+  used_pct: number | null;
+  cpu_cores: number | null;
+  cpu_used_pct: number | null;
+  mem_used_pct: number | null;
+  mem_limit: string | null;
+  num_running_queries: number | null;
+  warehouse: string | null;
+  version: string | null;
+  err_msg: string | null;
+}
+
+export interface ClusterMetrics {
+  fe_total: number;
+  fe_alive: number;
+  be_total: number;
+  be_alive: number;
+  cn_total: number;
+  cn_alive: number;
+  total_tablets: number | null;
+  total_data_used: string | null;
+  avg_disk_used_pct: number | null;
+  avg_cpu_used_pct: number | null;
+  avg_mem_used_pct: number | null;
+  avg_fe_heap_used_pct: number | null;
+}
+
+export interface ClusterStatusResponse {
+  frontends: FENodeInfo[];
+  backends: BENodeInfo[];
+  metrics: ClusterMetrics;
+  has_errors: boolean;
+  mode: "full" | "limited";
+  metrics_warning: string | null;
+}

--- a/frontend/src/utils/nodeNameUtils.test.ts
+++ b/frontend/src/utils/nodeNameUtils.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { shortenNodeName } from "./nodeNameUtils";
+
+describe("shortenNodeName", () => {
+  it("strips K8s FQDN to first DNS label", () => {
+    expect(shortenNodeName("starrocks-oss-cn-1.starrocks-oss-cn-search.starrocks-oss.svc.cluster.local"))
+      .toBe("starrocks-oss-cn-1");
+    expect(shortenNodeName("starrocks-oss-fe-0.ns.svc.cluster.local"))
+      .toBe("starrocks-oss-fe-0");
+  });
+
+  it("strips _<port>_<timestamp> suffix from FE names", () => {
+    expect(shortenNodeName("starrocks-oss-fe-0_9010_1775306864789"))
+      .toBe("starrocks-oss-fe-0");
+    expect(shortenNodeName("fe-01_9010_1234567890"))
+      .toBe("fe-01");
+  });
+
+  it("handles FQDN that also has suffix (strips dot first, then suffix)", () => {
+    expect(shortenNodeName("starrocks-oss-fe-0_9010_1775306864789.ns.svc.cluster.local"))
+      .toBe("starrocks-oss-fe-0");
+  });
+
+  it("leaves IPv4 addresses unchanged", () => {
+    expect(shortenNodeName("10.100.1.2")).toBe("10.100.1.2");
+    expect(shortenNodeName("192.168.0.1")).toBe("192.168.0.1");
+  });
+
+  it("leaves plain short names unchanged", () => {
+    expect(shortenNodeName("fe-01")).toBe("fe-01");
+    expect(shortenNodeName("20001")).toBe("20001");
+    expect(shortenNodeName("starrocks-oss-cn-0")).toBe("starrocks-oss-cn-0");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(shortenNodeName("")).toBe("");
+  });
+});

--- a/frontend/src/utils/nodeNameUtils.ts
+++ b/frontend/src/utils/nodeNameUtils.ts
@@ -1,0 +1,21 @@
+const _NAME_SUFFIX_RE = /_\d+_\d+$/;
+const _IPV4_RE = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+/**
+ * Returns a short display name for a StarRocks node identifier.
+ *
+ * Handles three forms that appear in K8s deployments:
+ *   - FQDN  "starrocks-oss-cn-1.ns.svc.cluster.local" → "starrocks-oss-cn-1"
+ *   - FE K8s "starrocks-oss-fe-0_9010_1775306864789"  → "starrocks-oss-fe-0"
+ *   - IPv4  "10.100.1.2"                              → "10.100.1.2"  (unchanged)
+ *   - plain  "fe-01"                                   → "fe-01"       (unchanged)
+ */
+export function shortenNodeName(name: string): string {
+  if (!name) return name;
+  // IPv4 addresses must not be split on "."
+  if (_IPV4_RE.test(name)) return name;
+  // FQDN: take only the first DNS label
+  const label = name.includes(".") ? name.split(".")[0] : name;
+  // Strip _<port>_<timestamp> suffix added by StarRocks for FE nodes
+  return label.replace(_NAME_SUFFIX_RE, "");
+}

--- a/frontend/src/utils/relativeTime.test.ts
+++ b/frontend/src/utils/relativeTime.test.ts
@@ -156,6 +156,11 @@ describe("formatRelativeTime", () => {
       const input = new Date(NOW.getTime() + 3 * 24 * 60 * 60 * 1000).toISOString();
       expect(formatRelativeTime(input, NOW)).toBe("in 3 days");
     });
+
+    it("returns 'just now' for a future timestamp within 5 seconds", () => {
+      const input = new Date(NOW.getTime() + 3 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("just now");
+    });
   });
 
   describe("time format support", () => {

--- a/frontend/src/utils/relativeTime.test.ts
+++ b/frontend/src/utils/relativeTime.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { formatRelativeTime } from "./relativeTime";
+
+// Fixed reference point: 2026-04-19T12:00:00Z
+const NOW = new Date("2026-04-19T12:00:00Z");
+
+describe("formatRelativeTime", () => {
+  describe("edge cases — invalid input", () => {
+    it("returns empty string for null", () => {
+      expect(formatRelativeTime(null, NOW)).toBe("");
+    });
+
+    it("returns empty string for undefined", () => {
+      expect(formatRelativeTime(undefined, NOW)).toBe("");
+    });
+
+    it("returns empty string for empty string", () => {
+      expect(formatRelativeTime("", NOW)).toBe("");
+    });
+
+    it("returns empty string for invalid date string", () => {
+      expect(formatRelativeTime("not-a-date", NOW)).toBe("");
+    });
+
+    it("returns empty string for random non-date text", () => {
+      expect(formatRelativeTime("hello world", NOW)).toBe("");
+    });
+  });
+
+  describe("just now (< 5 seconds)", () => {
+    it("returns 'just now' for 0 seconds ago", () => {
+      expect(formatRelativeTime("2026-04-19T12:00:00Z", NOW)).toBe("just now");
+    });
+
+    it("returns 'just now' for 3 seconds ago", () => {
+      const input = new Date(NOW.getTime() - 3 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("just now");
+    });
+
+    it("returns 'just now' for 4 seconds ago", () => {
+      const input = new Date(NOW.getTime() - 4 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("just now");
+    });
+  });
+
+  describe("seconds (5s–59s)", () => {
+    it("returns '5 seconds ago' for 5 seconds", () => {
+      const input = new Date(NOW.getTime() - 5 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("5 seconds ago");
+    });
+
+    it("returns '1 second ago' for 1 second (singular)", () => {
+      const input = new Date(NOW.getTime() - 1 * 1000).toISOString();
+      // 1 second < 5 seconds threshold, so it's "just now"
+      expect(formatRelativeTime(input, NOW)).toBe("just now");
+    });
+
+    it("returns '30 seconds ago' for 30 seconds", () => {
+      const input = new Date(NOW.getTime() - 30 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("30 seconds ago");
+    });
+
+    it("returns '59 seconds ago' for 59 seconds", () => {
+      const input = new Date(NOW.getTime() - 59 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("59 seconds ago");
+    });
+  });
+
+  describe("minutes (1m–59m)", () => {
+    it("returns '1 minute ago' for exactly 60 seconds (singular)", () => {
+      const input = new Date(NOW.getTime() - 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("1 minute ago");
+    });
+
+    it("returns '2 minutes ago' for 2 minutes (plural)", () => {
+      const input = new Date(NOW.getTime() - 2 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("2 minutes ago");
+    });
+
+    it("returns '59 minutes ago' for 59 minutes", () => {
+      const input = new Date(NOW.getTime() - 59 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("59 minutes ago");
+    });
+  });
+
+  describe("hours (1h–23h)", () => {
+    it("returns '1 hour ago' for exactly 1 hour (singular)", () => {
+      const input = new Date(NOW.getTime() - 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("1 hour ago");
+    });
+
+    it("returns '3 hours ago' for 3 hours (plural)", () => {
+      const input = new Date(NOW.getTime() - 3 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("3 hours ago");
+    });
+
+    it("returns '23 hours ago' for 23 hours", () => {
+      const input = new Date(NOW.getTime() - 23 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("23 hours ago");
+    });
+  });
+
+  describe("days (1d–29d)", () => {
+    it("returns '1 day ago' for exactly 1 day (singular)", () => {
+      const input = new Date(NOW.getTime() - 24 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("1 day ago");
+    });
+
+    it("returns '3 days ago' for 3 days (plural)", () => {
+      const input = new Date(NOW.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("3 days ago");
+    });
+
+    it("returns '29 days ago' for 29 days", () => {
+      const input = new Date(NOW.getTime() - 29 * 24 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("29 days ago");
+    });
+  });
+
+  describe("months (1mo–11mo)", () => {
+    it("returns '1 month ago' for 30 days (singular)", () => {
+      const input = new Date(NOW.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("1 month ago");
+    });
+
+    it("returns '3 months ago' for 90 days (plural)", () => {
+      const input = new Date(NOW.getTime() - 90 * 24 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("3 months ago");
+    });
+
+    it("returns '11 months ago' for 330 days", () => {
+      const input = new Date(NOW.getTime() - 330 * 24 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("11 months ago");
+    });
+  });
+
+  describe("years (1y+)", () => {
+    it("returns '1 year ago' for 365 days (singular)", () => {
+      const input = new Date(NOW.getTime() - 365 * 24 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("1 year ago");
+    });
+
+    it("returns '2 years ago' for 730 days (plural)", () => {
+      const input = new Date(NOW.getTime() - 730 * 24 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("2 years ago");
+    });
+  });
+
+  describe("future timestamps", () => {
+    it("returns 'in 2 minutes' for a timestamp 2 minutes in the future", () => {
+      const input = new Date(NOW.getTime() + 2 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("in 2 minutes");
+    });
+
+    it("returns 'in 3 days' for a timestamp 3 days in the future", () => {
+      const input = new Date(NOW.getTime() + 3 * 24 * 60 * 60 * 1000).toISOString();
+      expect(formatRelativeTime(input, NOW)).toBe("in 3 days");
+    });
+  });
+
+  describe("time format support", () => {
+    it("accepts ISO 8601 format with Z suffix", () => {
+      // 2 hours ago in ISO format
+      expect(formatRelativeTime("2026-04-19T10:00:00Z", NOW)).toBe("2 hours ago");
+    });
+
+    it("accepts space-separated format (treated as UTC)", () => {
+      // "2026-04-19 10:00:00" → 2 hours before NOW
+      expect(formatRelativeTime("2026-04-19 10:00:00", NOW)).toBe("2 hours ago");
+    });
+
+    it("ISO and space-separated produce identical results for same time", () => {
+      const iso = formatRelativeTime("2026-04-18T12:00:00Z", NOW);
+      const spaced = formatRelativeTime("2026-04-18 12:00:00", NOW);
+      expect(iso).toBe(spaced);
+      expect(iso).toBe("1 day ago");
+    });
+  });
+});

--- a/frontend/src/utils/relativeTime.ts
+++ b/frontend/src/utils/relativeTime.ts
@@ -1,0 +1,52 @@
+/**
+ * Format an absolute timestamp (ISO 8601 or "YYYY-MM-DD HH:MM:SS") as
+ * relative time like "2 minutes ago", "3 days ago", or "just now".
+ * Returns an empty string for null/undefined/invalid input.
+ */
+export function formatRelativeTime(
+  input: string | null | undefined,
+  now: Date = new Date(),
+): string {
+  if (input == null || input === "") return "";
+
+  // Normalize space-separated datetime to ISO 8601 UTC
+  // e.g. "2026-04-19 10:00:00" → "2026-04-19T10:00:00Z"
+  let normalized = input;
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(input)) {
+    normalized = input.replace(" ", "T") + "Z";
+  }
+
+  const date = new Date(normalized);
+  if (isNaN(date.getTime())) return "";
+
+  const diffMs = now.getTime() - date.getTime();
+  const isFuture = diffMs < 0;
+  const absMs = Math.abs(diffMs);
+
+  const seconds = Math.floor(absMs / 1000);
+  const minutes = Math.floor(absMs / (1000 * 60));
+  const hours = Math.floor(absMs / (1000 * 60 * 60));
+  const days = Math.floor(absMs / (1000 * 60 * 60 * 24));
+  const months = Math.floor(days / 30);
+  const years = Math.floor(days / 365);
+
+  let label: string;
+
+  if (seconds < 5) {
+    return "just now";
+  } else if (seconds < 60) {
+    label = `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+  } else if (minutes < 60) {
+    label = `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+  } else if (hours < 24) {
+    label = `${hours} ${hours === 1 ? "hour" : "hours"}`;
+  } else if (days < 30) {
+    label = `${days} ${days === 1 ? "day" : "days"}`;
+  } else if (months < 12) {
+    label = `${months} ${months === 1 ? "month" : "months"}`;
+  } else {
+    label = `${years} ${years === 1 ? "year" : "years"}`;
+  }
+
+  return isFuture ? `in ${label}` : `${label} ago`;
+}


### PR DESCRIPTION
Closes #17

## Summary

Adds a right-side cluster health drawer accessible to every logged-in user, and fixes several permission-gating issues surfaced during live testing.

### Cluster drawer
- FE/BE/CN node inventory from `SHOW FRONTENDS` / `SHOW BACKENDS` / `SHOW COMPUTE NODES`
- FE resource metrics (JVM heap %, Young/Old GC counters, query p99) probed in parallel from each FE's unauthenticated Prometheus `/metrics` endpoint on port 8030 (2 s per-node timeout, stdlib-only parser in `backend/app/services/fe_metrics.py`)
- Shared-data cluster support: CN local cache usage parsed from `DataCacheMetrics`
- **Limited-mode fallback**: users without `cluster_admin` see only the FE they're connected to with a banner, instead of a 403
- K8s-friendly node-name shortening (`starrocks-oss-fe-0_9010_1775306864789` → `starrocks-oss-fe-0`, FQDN → first DNS label) with IPv4 detection; `ip` hidden from header when it equals the display name

### Permission gating fixes (discovered during testing)
- `can_access_sys()` now runs `SET ROLE ALL` and verifies **all four** queries that admin routes depend on: `SELECT FROM sys.{role_edges, grants_to_users, grants_to_roles}` + `SHOW ROLES`. Users with only partial sys-table access no longer get `is_admin=true` (which previously caused opaque 500s). **`user_admin` or `security_admin` is now required** — `cluster_admin` alone is not enough. Documented in `CLAUDE.md` and `README.md`.
- `get_db()` runs `SET ROLE ALL` on every new connection (wrapped in try/except — non-fatal)
- Global `mysql.connector.errors.Error` handler maps errno in `{1044, 1045, 1142, 1227}` to HTTP 403 instead of leaking 500s
- `App.tsx` redirects `#perm` → `#obj` for non-admins and gates `PermissionDetailTab` on `isAdmin` (defends against direct URL navigation)
- `_build_role_hierarchy_from_grants()` always includes the implicit `public` role in the non-admin Role Map DAG
- `authStore` persists connection info (host:port) to localStorage so the header subtitle survives refresh
- Second early-return in `App.tsx` during session-restore window (`isLoggedIn && !user`) prevents the admin-tab flicker on refresh

### API
New endpoint: `GET /api/cluster/status` — docs in `docs/API.md` include the `mode` / `metrics_warning` fields, CN shape, and `/metrics`-derived FE fields.

## Test plan

- [x] Backend: `pytest tests/ --ignore=tests/test_integration.py` (173 tests pass)
- [x] Backend lint: `ruff check backend/app/` clean
- [x] Frontend: `tsc --noEmit` + `eslint --max-warnings 0` + `vitest run` (334 tests pass across 29 files)
- [x] Docker build + deploy on port 8002
- [x] Live — admin login: full FE/BE/CN inventory, heap % shows in FE cards
- [x] Live — non-admin login: limited-mode banner, single FE, `public` role appears in Role Map
- [x] Live — partial-admin (sys-table SELECT only, no `user_admin`): correctly classified as non-admin; no admin tabs; no 500s
- [x] Live — page refresh: session restores without tab flicker for admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)