### PR TITLE
Bugfix: address ultra-review findings from cluster-status drawer (#40)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.routers import (
     user_roles,
     user_search,
 )
+from app.routers.cluster import shutdown_metrics_executor
 from app.utils.session_store import session_store
 from app.utils.sys_access import is_access_denied
 
@@ -40,6 +41,7 @@ async def lifespan(app: FastAPI):
     yield
     # Shutdown
     cleanup_task.cancel()
+    shutdown_metrics_executor()
 
 
 app = FastAPI(title=settings.app_name, version="1.0.0", lifespan=lifespan)

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel
 
 
@@ -153,7 +155,7 @@ class FENodeInfo(BaseModel):
 class BENodeInfo(BaseModel):
     name: str
     ip: str
-    node_type: str = "backend"  # "backend" (SHOW BACKENDS) or "compute" (SHOW COMPUTE NODES)
+    node_type: Literal["backend", "compute"] = "backend"  # "backend" (SHOW BACKENDS) or "compute" (SHOW COMPUTE NODES)
     heartbeat_port: int | None = None
     be_port: int | None = None
     http_port: int | None = None
@@ -195,5 +197,5 @@ class ClusterStatusResponse(BaseModel):
     backends: list[BENodeInfo]
     metrics: ClusterMetrics
     has_errors: bool
-    mode: str = "full"  # "full" = SHOW succeeded; "limited" = access-denied fallback
+    mode: Literal["full", "limited"] = "full"  # "full" = SHOW succeeded; "limited" = access-denied fallback
     metrics_warning: str | None = None  # set iff all FE /metrics fetches failed

--- a/backend/app/routers/cluster.py
+++ b/backend/app/routers/cluster.py
@@ -22,7 +22,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import mysql.connector.errors
 from cachetools import TTLCache
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from app.config import settings
 from app.dependencies import get_credentials, get_db
@@ -40,8 +40,16 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 # ── TTL cache (per username) ──
-_cluster_cache: TTLCache = TTLCache(maxsize=8, ttl=settings.cache_ttl_seconds)
+_cluster_cache: TTLCache = TTLCache(maxsize=256, ttl=settings.cache_ttl_seconds)
 _cluster_cache_lock = threading.Lock()
+
+# Module-level executor — reused across requests to avoid per-request thread-pool creation overhead.
+_metrics_executor = ThreadPoolExecutor(max_workers=6, thread_name_prefix="fe-metrics")
+
+
+def shutdown_metrics_executor() -> None:
+    """Shutdown the module-level FE metrics executor. Called from FastAPI lifespan."""
+    _metrics_executor.shutdown(wait=False)
 
 
 # ── Parse helpers ──
@@ -296,11 +304,14 @@ _METRICS_TIMEOUT_SECONDS = 2.0
 def _limited_mode_fe(host: str) -> FENodeInfo:
     """Build a best-effort FENodeInfo for non-cluster_admin users.
 
-    Only fields we can know without SHOW FRONTENDS: host/port and a placeholder
-    role. Resource fields are filled in afterwards from /metrics.
+    `host` is the StarRocks address the caller already authenticated against
+    (from `LoginRequest.host`, validated by the MySQL credential handshake in
+    `get_connection`). `_inject_metrics` only reaches `http://{host}:8030/metrics`
+    after that handshake succeeded — no new SSRF surface beyond the existing SR
+    connection path.
     """
     return FENodeInfo(
-        name=host,
+        name="FE (connected)",
         ip=host,
         http_port=_DEFAULT_FE_HTTP_PORT,
         role="UNKNOWN",
@@ -322,19 +333,21 @@ def _inject_metrics(frontends: list[FENodeInfo]) -> str | None:
         port = fe.http_port or _DEFAULT_FE_HTTP_PORT
         return fe, fetch_fe_metrics(fe.ip, port, timeout=_METRICS_TIMEOUT_SECONDS)
 
+    # Submit all probes to the module-level executor; collect futures in order.
     any_success = False
-    with ThreadPoolExecutor(max_workers=min(3, len(frontends))) as pool:
-        for fe, result in pool.map(_probe, frontends):
-            if isinstance(result, FEMetricsData):
-                any_success = True
-                fe.jvm_heap_used_pct = result.heap_used_pct
-                fe.gc_young_count = result.gc_young_count
-                fe.gc_young_time_ms = result.gc_young_time_ms
-                fe.gc_old_count = result.gc_old_count
-                fe.gc_old_time_ms = result.gc_old_time_ms
-                fe.query_p99_ms = result.query_p99_ms
-            else:
-                fe.metrics_error = f"{result.reason}: {result.message}"
+    futures = [_metrics_executor.submit(_probe, fe) for fe in frontends]
+    for future in futures:
+        fe, result = future.result()
+        if isinstance(result, FEMetricsData):
+            any_success = True
+            fe.jvm_heap_used_pct = result.heap_used_pct
+            fe.gc_young_count = result.gc_young_count
+            fe.gc_young_time_ms = result.gc_young_time_ms
+            fe.gc_old_count = result.gc_old_count
+            fe.gc_old_time_ms = result.gc_old_time_ms
+            fe.query_p99_ms = result.query_p99_ms
+        else:
+            fe.metrics_error = f"{result.reason}: {result.message}"
 
     if not any_success:
         return (
@@ -349,12 +362,16 @@ def _inject_metrics(frontends: list[FENodeInfo]) -> str | None:
 def get_cluster_status(
     conn=Depends(get_db),
     credentials: dict = Depends(get_credentials),
+    refresh: bool = Query(False, description="Bypass per-user cache and force a live query"),
 ):
     """Return FE/BE/CN inventory + resource metrics.
 
     No require_admin guard — any logged-in user may call this. When StarRocks
     denies SHOW FRONTENDS (no cluster_admin role), we fall back to a single-FE
     "limited" view so basic cluster health is still visible (common UI).
+
+    Pass `?refresh=1` to bypass the cache for this request; the result is still
+    written back to cache so the next non-refresh call remains fast.
     """
     username = credentials["username"]
     host = credentials.get("host") or ""
@@ -369,17 +386,13 @@ def get_cluster_status(
         with _cluster_cache_lock:
             _cluster_cache[f"cluster_status_{username}:{mode}"] = resp
 
-    # Fast path: serve either mode from cache if present.
-    for cached_mode in ("full", "limited"):
-        hit = _cached(cached_mode)
+    # Fast path: serve from cache if present (skipped when refresh=True).
+    if not refresh:
+        hit = _cached("full") or _cached("limited")
         if hit is not None:
             return hit
 
-    # Activate all granted roles so non-default roles like cluster_admin apply.
-    try:
-        execute_query(conn, "SET ROLE ALL")
-    except Exception:
-        logger.debug("Failed to SET ROLE ALL for user %s", username)
+    # get_db() already runs SET ROLE ALL; no need to repeat it here.
 
     mode = "full"
     fe_rows: list[dict] = []
@@ -419,7 +432,7 @@ def get_cluster_status(
                 cn_rows = []
                 logger.debug("SHOW COMPUTE NODES denied — downgrading to limited mode")
             else:
-                logger.debug("SHOW COMPUTE NODES not available: %s", exc)
+                logger.warning("SHOW COMPUTE NODES failed (non-access-denied): %s", exc)
 
     # Build node lists.
     if mode == "full":

--- a/backend/app/services/fe_metrics.py
+++ b/backend/app/services/fe_metrics.py
@@ -101,14 +101,14 @@ def fetch_fe_metrics(
         return FEMetricsError(reason="timeout", message=f"timeout after {timeout}s")
     except urllib.error.HTTPError as exc:
         return FEMetricsError(reason="http_status", message=f"HTTP {exc.code}")
-    except urllib.error.URLError as exc:
-        return FEMetricsError(reason="network", message=str(exc.reason))
-    except Exception as exc:  # noqa: BLE001  - graceful degradation is the goal
-        logger.debug("Unexpected /metrics fetch error for %s:%s: %s", host, http_port, exc)
+    except (urllib.error.URLError, ConnectionError, OSError) as exc:
+        return FEMetricsError(reason="network", message=str(exc))
+    except Exception as exc:  # noqa: BLE001  - last-resort fallback; unexpected errors logged
+        logger.exception("Unexpected error fetching FE metrics from %s:%s", host, http_port)
         return FEMetricsError(reason="unknown", message=str(exc))
 
     try:
         return _parse_metrics_body(body)
     except Exception as exc:  # noqa: BLE001
-        logger.debug("Parse error for %s:%s: %s", host, http_port, exc)
+        logger.exception("Parse error for FE metrics from %s:%s", host, http_port)
         return FEMetricsError(reason="parse", message=str(exc))

--- a/backend/tests/test_cluster_status.py
+++ b/backend/tests/test_cluster_status.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+
 import mysql.connector.errors
 import pytest
 
@@ -10,7 +12,16 @@ from app.services.fe_metrics import FEMetricsData, FEMetricsError
 
 @pytest.fixture(autouse=True)
 def _stub_fe_metrics(monkeypatch):
-    """Default: return a deterministic FEMetricsData so tests don't hit the network."""
+    """Default: return a deterministic FEMetricsData so tests don't hit the network.
+
+    Also replaces the module-level _metrics_executor with a fresh one for each test.
+    The FastAPI lifespan shutdown (triggered by TestClient.__exit__) calls
+    shutdown_metrics_executor(), which permanently shuts down the module-level
+    ThreadPoolExecutor.  Without this replacement the second test in the session
+    would see a shut-down executor and raise RuntimeError.
+    """
+    import app.routers.cluster as cluster_mod
+
     def _fake(host, http_port, timeout=2.0):
         return FEMetricsData(
             heap_used_pct=5.0,
@@ -20,8 +31,12 @@ def _stub_fe_metrics(monkeypatch):
             gc_old_time_ms=0,
             query_p99_ms=12.3,
         )
-    import app.routers.cluster as cluster_mod
+
     monkeypatch.setattr(cluster_mod, "fetch_fe_metrics", _fake)
+    # Provide a fresh executor so that lifespan-shutdown from a previous test
+    # doesn't leave the singleton in a shut-down state.
+    fresh_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="fe-metrics-test")
+    monkeypatch.setattr(cluster_mod, "_metrics_executor", fresh_executor)
 
 
 # ── Happy path ──
@@ -176,6 +191,10 @@ def test_cluster_status_limited_mode(client, auth_header, monkeypatch):
     assert data["backends"] == []
     fe = data["frontends"][0]
     assert fe["role"] == "UNKNOWN"
+    # M3: placeholder name must be the fixed string "FE (connected)"
+    assert fe["name"] == "FE (connected)"
+    # The IP should still reflect the login host so the UI can show the real address
+    assert fe["ip"] == "test-sr-host"
     # /metrics stub still fires on the placeholder FE
     assert fe["jvm_heap_used_pct"] == pytest.approx(5.0)
     cluster_mod._cluster_cache.clear()
@@ -284,6 +303,143 @@ def test_cluster_status_cached(client, auth_header, monkeypatch):
 
     # First request: 3 SHOW calls (SHOW FRONTENDS + SHOW BACKENDS + SHOW COMPUTE NODES).
     # Second request: served from cache → still 3 total.
-    # (SET ROLE ALL runs each time but it is cheap, so we don't count it.)
+    # Note: SET ROLE ALL is no longer called inside get_cluster_status() (M2 — removed
+    # the duplicate call; get_db() already runs it). We only count SHOW-prefixed queries.
     assert show_calls == 3
+    cluster_mod._cluster_cache.clear()
+
+
+# ── H2: ?refresh=1 bypasses cache ──
+
+def test_cluster_status_refresh_bypass(client, auth_header, monkeypatch):
+    """?refresh=1 must skip the cache read and re-execute the SHOW queries.
+
+    Sequence:
+      1. Normal call  → populates cache (3 SHOW calls)
+      2. refresh call → cache read skipped, queries re-run (3 more = 6 total)
+      3. Normal call  → cache hit from refresh's write-back (still 6 total)
+    """
+    import app.routers.cluster as cluster_mod
+
+    show_calls = 0
+    original = cluster_mod.execute_query
+
+    def _counting(conn, sql, params=None):
+        nonlocal show_calls
+        if sql.strip().upper().startswith("SHOW "):
+            show_calls += 1
+        return original(conn, sql, params)
+
+    monkeypatch.setattr(cluster_mod, "execute_query", _counting)
+    cluster_mod._cluster_cache.clear()
+
+    # 1. Normal call — populates cache.
+    resp1 = client.get("/api/cluster/status", headers=auth_header)
+    assert resp1.status_code == 200
+    after_first = show_calls
+    assert after_first == 3  # SHOW FRONTENDS + SHOW BACKENDS + SHOW COMPUTE NODES
+
+    # 2. Refresh call — bypasses cache read, runs queries again.
+    resp2 = client.get("/api/cluster/status?refresh=1", headers=auth_header)
+    assert resp2.status_code == 200
+    after_refresh = show_calls
+    assert after_refresh == 6  # 3 new SHOW calls on top of the first 3
+
+    # 3. Normal call — served from the cache written by the refresh call.
+    resp3 = client.get("/api/cluster/status", headers=auth_header)
+    assert resp3.status_code == 200
+    assert show_calls == 6  # count unchanged — came from cache
+
+    cluster_mod._cluster_cache.clear()
+
+
+# ── SHOW BACKENDS access-denied: frontends populated, backends empty ──
+
+def test_cluster_status_be_only_denied(client, auth_header, monkeypatch):
+    """SHOW FRONTENDS succeeds but SHOW BACKENDS raises access-denied.
+
+    Expected: 200, mode='full', frontends populated from fixture, backends=[].
+    (The handler downgrades to limited mode when BACKENDS is denied, so we
+    verify the limited-mode path only clears backends not frontends.)
+    """
+    import app.routers.cluster as cluster_mod
+
+    access_denied = mysql.connector.errors.ProgrammingError(
+        msg="Access denied for user 'viewer'@'%'",
+        errno=1044,
+    )
+    original = cluster_mod.execute_query
+
+    def _deny_backends(conn, sql, params=None):
+        up = sql.strip().upper()
+        if up.startswith("SHOW BACKENDS"):
+            raise access_denied
+        return original(conn, sql, params)
+
+    monkeypatch.setattr(cluster_mod, "execute_query", _deny_backends)
+    cluster_mod._cluster_cache.clear()
+
+    resp = client.get("/api/cluster/status", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # When SHOW BACKENDS is denied the router downgrades to limited mode.
+    # In limited mode frontends is replaced by the placeholder FE.
+    assert data["mode"] == "limited"
+    assert len(data["frontends"]) == 1
+    assert data["frontends"][0]["name"] == "FE (connected)"
+    assert data["backends"] == []
+
+    cluster_mod._cluster_cache.clear()
+
+
+# ── SHOW COMPUTE NODES non-access-denied error: warning logged, CN absent ──
+
+def test_cluster_status_cn_silent_on_generic_error(client, auth_header, monkeypatch, caplog):
+    """SHOW COMPUTE NODES fails with a non-access-denied error.
+
+    Expected: 200, FE/BE still present, CN absent, logger.warning fired with
+    a message containing 'SHOW COMPUTE NODES failed'.
+    """
+    import logging
+
+    import app.routers.cluster as cluster_mod
+
+    generic_err = mysql.connector.errors.ProgrammingError(
+        msg="Connection lost",
+        errno=2006,
+    )
+    original = cluster_mod.execute_query
+
+    def _fail_cn(conn, sql, params=None):
+        up = sql.strip().upper()
+        if up.startswith("SHOW COMPUTE NODES"):
+            raise generic_err
+        return original(conn, sql, params)
+
+    monkeypatch.setattr(cluster_mod, "execute_query", _fail_cn)
+    cluster_mod._cluster_cache.clear()
+
+    with caplog.at_level(logging.WARNING, logger="app.routers.cluster"):
+        resp = client.get("/api/cluster/status", headers=auth_header)
+
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Full mode: SHOW FRONTENDS and SHOW BACKENDS succeeded.
+    assert data["mode"] == "full"
+    # FE nodes from fixture
+    assert len(data["frontends"]) == 2
+    # BE nodes from fixture (CN absent because SHOW COMPUTE NODES failed)
+    be_nodes = [b for b in data["backends"] if b["node_type"] == "backend"]
+    cn_nodes = [b for b in data["backends"] if b["node_type"] == "compute"]
+    assert len(be_nodes) == 2
+    assert len(cn_nodes) == 0
+
+    # logger.warning must have been emitted with the expected substring
+    warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("SHOW COMPUTE NODES failed" in m for m in warning_msgs), (
+        f"Expected 'SHOW COMPUTE NODES failed' in warnings; got: {warning_msgs}"
+    )
+
     cluster_mod._cluster_cache.clear()

--- a/backend/tests/test_error_handler.py
+++ b/backend/tests/test_error_handler.py
@@ -1,0 +1,69 @@
+"""Integration tests for the global mysql_error_handler in main.py.
+
+Strategy: monkeypatch an existing route's underlying function to raise a
+mysql.connector.errors.ProgrammingError, then call that route and verify
+the HTTP status and response body produced by the exception handler.
+
+We use GET /api/auth/me because:
+  - it requires only a valid auth header (no body)
+  - it calls `get_user_roles` → easy to intercept at the router function level
+"""
+
+from __future__ import annotations
+
+import mysql.connector.errors
+import pytest
+
+
+class TestMysqlErrorHandler:
+    """Tests for the global mysql_error_handler exception handler."""
+
+    def test_mysql_error_handler_maps_1044_to_403(self, client, auth_header, monkeypatch):
+        """errno 1044 (DB access denied) → HTTP 403 with standard detail."""
+        import app.routers.auth as auth_mod
+
+        def _raise(*args, **kwargs):
+            raise mysql.connector.errors.ProgrammingError(
+                msg="Access denied for user 'x'@'%' to database 'sys'",
+                errno=1044,
+            )
+
+        monkeypatch.setattr(auth_mod, "get_user_roles", _raise)
+
+        resp = client.get("/api/auth/me", headers=auth_header)
+        assert resp.status_code == 403
+        detail = resp.json()["detail"]
+        assert "Insufficient database privileges" in detail
+
+    def test_mysql_error_handler_maps_1227_to_403(self, client, auth_header, monkeypatch):
+        """errno 1227 (SYSTEM op denied) → HTTP 403 with standard detail."""
+        import app.routers.auth as auth_mod
+
+        def _raise(*args, **kwargs):
+            raise mysql.connector.errors.ProgrammingError(
+                msg="Access denied; you need (at least one of) the SUPER privilege(s) for this operation",
+                errno=1227,
+            )
+
+        monkeypatch.setattr(auth_mod, "get_user_roles", _raise)
+
+        resp = client.get("/api/auth/me", headers=auth_header)
+        assert resp.status_code == 403
+        detail = resp.json()["detail"]
+        assert "Insufficient database privileges" in detail
+
+    def test_mysql_error_handler_maps_unknown_errno_to_500(self, client, auth_header, monkeypatch):
+        """An unrecognised errno (not in ACCESS_DENIED_ERRNOS) → HTTP 500, detail='Database error'."""
+        import app.routers.auth as auth_mod
+
+        def _raise(*args, **kwargs):
+            raise mysql.connector.errors.ProgrammingError(
+                msg="Some completely unrelated database error",
+                errno=9999,
+            )
+
+        monkeypatch.setattr(auth_mod, "get_user_roles", _raise)
+
+        resp = client.get("/api/auth/me", headers=auth_header)
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Database error"

--- a/backend/tests/test_sys_access.py
+++ b/backend/tests/test_sys_access.py
@@ -1,0 +1,141 @@
+"""Unit tests for app.utils.sys_access — is_access_denied() and can_access_sys()."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import mysql.connector.errors
+import pytest
+
+from app.utils.sys_access import is_access_denied, can_access_sys
+
+
+# ── is_access_denied ──
+
+
+class TestIsAccessDenied:
+    """Tests for the is_access_denied() helper."""
+
+    @pytest.mark.parametrize("errno", [1044, 1045, 1142, 1227])
+    def test_known_access_denied_errnos_return_true(self, errno):
+        """Standard MySQL access-denied errnos must all return True."""
+        exc = mysql.connector.errors.ProgrammingError(
+            msg="Access denied for user 'x'@'localhost'",
+            errno=errno,
+        )
+        assert is_access_denied(exc) is True
+
+    def test_errno_none_with_access_denied_message_returns_true(self):
+        """When errno is absent but the message contains 'Access denied', return True."""
+        exc = mysql.connector.errors.ProgrammingError(
+            msg="Access denied for user 'x'@'%' to database 'sys'",
+            errno=None,
+        )
+        assert is_access_denied(exc) is True
+
+    def test_errno_none_with_unrelated_message_returns_false(self):
+        """errno=None and no 'Access denied' substring → False."""
+        exc = mysql.connector.errors.ProgrammingError(
+            msg="Syntax error near 'SLECT'",
+            errno=None,
+        )
+        assert is_access_denied(exc) is False
+
+    def test_unknown_errno_returns_false(self):
+        """An unrecognised errno (not in ACCESS_DENIED_ERRNOS) → False."""
+        exc = mysql.connector.errors.ProgrammingError(
+            msg="some other error",
+            errno=9999,
+        )
+        assert is_access_denied(exc) is False
+
+    def test_value_error_without_errno_returns_false(self):
+        """Non-mysql exception without errno attribute → False (no AttributeError)."""
+        exc = ValueError("nothing")
+        assert is_access_denied(exc) is False
+
+    def test_plain_exception_without_errno_returns_false(self):
+        """Generic Exception without errno → False."""
+        exc = Exception("nothing")
+        assert is_access_denied(exc) is False
+
+
+# ── can_access_sys ──
+
+
+def _make_execute_query_side_effect(fail_on: str):
+    """Return a fake execute_query that raises ProgrammingError when SQL contains `fail_on`."""
+    def _fake(conn, sql, params=None):
+        if fail_on in sql:
+            raise mysql.connector.errors.ProgrammingError(
+                msg=f"SELECT command denied to user for table '{fail_on}'",
+                errno=1142,
+            )
+        return [{"1": 1}]
+    return _fake
+
+
+class TestCanAccessSys:
+    """Tests for the can_access_sys() helper.
+
+    We monkeypatch `app.utils.sys_access.execute_query` at the module level
+    so the function under test uses our fake rather than a real DB call.
+    """
+
+    def test_all_queries_succeed_returns_true(self, monkeypatch):
+        """When every query succeeds, the user has full sys access → True."""
+        def _ok(conn, sql, params=None):
+            return [{"1": 1}]
+
+        monkeypatch.setattr("app.utils.sys_access.execute_query", _ok)
+        assert can_access_sys(MagicMock()) is True
+
+    def test_set_role_all_fails_but_queries_succeed_returns_true(self, monkeypatch):
+        """SET ROLE ALL failure is non-fatal; if all table queries pass → True."""
+        def _fail_set_role(conn, sql, params=None):
+            if sql.strip().upper().startswith("SET ROLE"):
+                raise mysql.connector.errors.ProgrammingError(
+                    msg="SET ROLE not allowed",
+                    errno=1227,
+                )
+            return [{"1": 1}]
+
+        monkeypatch.setattr("app.utils.sys_access.execute_query", _fail_set_role)
+        assert can_access_sys(MagicMock()) is True
+
+    def test_role_edges_failure_returns_false(self, monkeypatch):
+        """Failure on sys.role_edges query → False."""
+        monkeypatch.setattr(
+            "app.utils.sys_access.execute_query",
+            _make_execute_query_side_effect("sys.role_edges"),
+        )
+        assert can_access_sys(MagicMock()) is False
+
+    def test_grants_to_users_failure_returns_false(self, monkeypatch):
+        """Failure on sys.grants_to_users query → False."""
+        monkeypatch.setattr(
+            "app.utils.sys_access.execute_query",
+            _make_execute_query_side_effect("sys.grants_to_users"),
+        )
+        assert can_access_sys(MagicMock()) is False
+
+    def test_grants_to_roles_failure_returns_false(self, monkeypatch):
+        """Failure on sys.grants_to_roles query → False."""
+        monkeypatch.setattr(
+            "app.utils.sys_access.execute_query",
+            _make_execute_query_side_effect("sys.grants_to_roles"),
+        )
+        assert can_access_sys(MagicMock()) is False
+
+    def test_show_roles_failure_returns_false(self, monkeypatch):
+        """Failure on SHOW ROLES query → False."""
+        def _fail_show_roles(conn, sql, params=None):
+            if sql.strip().upper().startswith("SHOW ROLES"):
+                raise mysql.connector.errors.ProgrammingError(
+                    msg="SHOW ROLES denied",
+                    errno=1044,
+                )
+            return [{"1": 1}]
+
+        monkeypatch.setattr("app.utils.sys_access.execute_query", _fail_show_roles)
+        assert can_access_sys(MagicMock()) is False

--- a/frontend/src/api/cluster.ts
+++ b/frontend/src/api/cluster.ts
@@ -7,5 +7,8 @@
 import { apiFetch } from "./client";
 import type { ClusterStatusResponse } from "../types";
 
-export const getClusterStatus = (signal?: AbortSignal) =>
-  apiFetch<ClusterStatusResponse>("/cluster/status", { signal });
+export const getClusterStatus = (signal?: AbortSignal, refresh?: boolean) =>
+  apiFetch<ClusterStatusResponse>(
+    refresh ? "/cluster/status?refresh=1" : "/cluster/status",
+    { signal },
+  );

--- a/frontend/src/components/cluster/ClusterDrawer.test.tsx
+++ b/frontend/src/components/cluster/ClusterDrawer.test.tsx
@@ -709,5 +709,87 @@ describe("ClusterDrawer", () => {
       screen.getByTitle("Refresh").click();
       expect(mockGetClusterStatus).toHaveBeenCalledTimes(2);
     });
+
+    it("refresh button passes refresh=true to getClusterStatus", async () => {
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
+
+      screen.getByTitle("Refresh").click();
+      await waitFor(() => expect(mockGetClusterStatus).toHaveBeenCalledTimes(2));
+
+      // Second call must have refresh=true as its second argument
+      expect(mockGetClusterStatus.mock.calls[1][1]).toBe(true);
+    });
+  });
+
+  describe("CN-only cluster", () => {
+    it("renders summary card without crashing and shows CN counts", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          backends: [
+            makeBENode({ node_type: "compute", name: "cn-01", ip: "10.0.0.3" }),
+            makeBENode({ node_type: "compute", name: "cn-02", ip: "10.0.0.4" }),
+          ],
+          metrics: {
+            fe_total: 1, fe_alive: 1, be_total: 0, be_alive: 0,
+            cn_total: 2, cn_alive: 2,
+            total_tablets: null, total_data_used: null,
+            avg_disk_used_pct: null, avg_cpu_used_pct: null,
+            avg_mem_used_pct: null, avg_fe_heap_used_pct: null,
+          },
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
+
+      // CN 2/2 alive is shown in summary
+      expect(screen.getByText(/2\/2/)).toBeInTheDocument();
+      // No BE row since be_total === 0
+      expect(screen.queryByText("BE")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("AbortController on unmount", () => {
+    it("calls abort when component unmounts while open", async () => {
+      const abortSpy = vi.spyOn(AbortController.prototype, "abort");
+
+      useClusterStore.setState({ isOpen: true });
+      const { unmount } = render(<ClusterDrawer />);
+
+      unmount();
+
+      expect(abortSpy).toHaveBeenCalled();
+      abortSpy.mockRestore();
+    });
+  });
+
+  describe("limited-mode FE label", () => {
+    it("displays 'FE (connected)' name and shortened host IP in limited mode", async () => {
+      mockGetClusterStatus.mockResolvedValue(
+        makeClusterData({
+          mode: "limited",
+          frontends: [
+            makeFENode({ name: "FE (connected)", ip: "starrocks.example.com" }),
+          ],
+          metrics: {
+            fe_total: 1, fe_alive: 1, be_total: 0, be_alive: 0,
+            cn_total: 0, cn_alive: 0,
+            total_tablets: null, total_data_used: null,
+            avg_disk_used_pct: null, avg_cpu_used_pct: null,
+            avg_mem_used_pct: null, avg_fe_heap_used_pct: null,
+          },
+        }),
+      );
+      useClusterStore.setState({ isOpen: true });
+      render(<ClusterDrawer />);
+      await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
+
+      // Node name displayed as-is (no mangling)
+      expect(screen.getByText("FE (connected)")).toBeInTheDocument();
+      // Shortened IP (first DNS label) shown separately
+      expect(screen.getByText("starrocks")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/cluster/ClusterDrawer.tsx
+++ b/frontend/src/components/cluster/ClusterDrawer.tsx
@@ -260,7 +260,7 @@ export default function ClusterDrawer() {
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
-  const fetchData = useCallback(() => {
+  const fetchData = useCallback((refresh = false) => {
     // Cancel any in-flight request
     abortRef.current?.abort();
     const controller = new AbortController();
@@ -269,7 +269,7 @@ export default function ClusterDrawer() {
     setLoading(true);
     setError(null);
 
-    getClusterStatus(controller.signal)
+    getClusterStatus(controller.signal, refresh)
       .then((res) => {
         setData(res);
         setLoading(false);
@@ -354,7 +354,7 @@ export default function ClusterDrawer() {
 
           {/* Refresh button */}
           <button
-            onClick={fetchData}
+            onClick={() => fetchData(true)}
             disabled={loading}
             title="Refresh"
             style={{
@@ -400,7 +400,7 @@ export default function ClusterDrawer() {
             }}>
               Failed to load cluster status.{" "}
               <button
-                onClick={fetchData}
+                onClick={() => fetchData()}
                 style={{ background: "none", border: "none", color: C.accent, cursor: "pointer", fontSize: 12, padding: 0, fontFamily: "inherit" }}
               >
                 Retry

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { UserInfo } from "../types";
 import { logoutApi } from "../api/auth";
+import { useClusterStore } from "./clusterStore";
 
 interface AuthState {
   token: string | null;
@@ -38,6 +39,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     localStorage.removeItem("sr_token");
     localStorage.removeItem("sr_connection");
     set({ token: null, user: null, isLoggedIn: false, connectionInfo: null });
+    useClusterStore.getState().reset();
   },
   setConnectionInfo: (host, port) => {
     localStorage.setItem("sr_connection", JSON.stringify({ host, port }));

--- a/frontend/src/stores/clusterStore.ts
+++ b/frontend/src/stores/clusterStore.ts
@@ -8,6 +8,7 @@ interface ClusterState {
   expandedNodes: Set<string>;
   toggleNodeExpansion: (id: string) => void;
   collapseAll: () => void;
+  reset: () => void;
 }
 
 export const useClusterStore = create<ClusterState>((set) => ({
@@ -24,4 +25,5 @@ export const useClusterStore = create<ClusterState>((set) => ({
       return { expandedNodes: next };
     }),
   collapseAll: () => set({ expandedNodes: new Set<string>() }),
+  reset: () => set({ isOpen: false, expandedNodes: new Set<string>() }),
 }));

--- a/frontend/src/utils/relativeTime.ts
+++ b/frontend/src/utils/relativeTime.ts
@@ -2,6 +2,12 @@
  * Format an absolute timestamp (ISO 8601 or "YYYY-MM-DD HH:MM:SS") as
  * relative time like "2 minutes ago", "3 days ago", or "just now".
  * Returns an empty string for null/undefined/invalid input.
+ *
+ * **UTC assumption**: Space-separated timestamps (e.g. `"2026-04-19 10:00:00"`)
+ * are assumed to be UTC because that's the StarRocks default. If your StarRocks
+ * server runs in a non-UTC timezone, offsets displayed as "X minutes ago" will
+ * be wrong by the TZ offset. Most production deployments use UTC, so this is
+ * usually a non-issue.
  */
 export function formatRelativeTime(
   input: string | null | undefined,


### PR DESCRIPTION
Closes #40
Stacked on #39 — this PR builds on `feature/cluster-status`; GitHub will auto-shrink the diff once #39 merges.

## Summary

Addresses the ultra-review findings against #39 according to the options confirmed with the reviewer. No net new features — all changes are hardening / UX polish / documented behavior.

### Behavior-changing fixes (confirmed in review)
- **H2** `GET /api/cluster/status?refresh=1` — drawer refresh button now busts the per-user cache without waiting for TTL. Without `refresh=1`, behavior is unchanged.
- **M1** `SHOW COMPUTE NODES` non-access-denied errors are now `logger.warning` instead of `logger.debug`. Response shape unchanged.
- **M3** Limited-mode FE card label is now the static string `"FE (connected)"` instead of the mangled shortened hostname. The actual host is still visible as the IP column.
- **L2** `fetch_fe_metrics` narrows expected network exceptions and logs `logger.exception` for truly unexpected errors. Graceful degradation preserved — callers still receive `FEMetricsError`.

### Correctness / observability (no behavior change)
- **H1** `_limited_mode_fe` docstring explains why the host value is SSRF-safe (already authenticated via MySQL handshake).
- **H3** `_cluster_cache` bumped from `maxsize=8` to `maxsize=256`.
- **M2** Duplicate `SET ROLE ALL` call in `cluster.py` removed — `get_db()` already runs it.
- **M5 / L5** `BENodeInfo.node_type` and `ClusterStatusResponse.mode` are now Pydantic `Literal` unions.
- **M6** `clusterStore` gains a `reset()` action called from `authStore.logout()` so drawer state cannot leak between sessions.
- **L1** `ThreadPoolExecutor` is now module-scoped and shut down via FastAPI lifespan.
- **M4** `formatRelativeTime` JSDoc documents the UTC-assumed behavior for space-separated timestamps.

### Test additions
- `backend/tests/test_sys_access.py` (new) — 15 unit tests covering `is_access_denied` and `can_access_sys` failure paths.
- `backend/tests/test_error_handler.py` (new) — global MySQL error handler mapping (1044/1227 → 403, else → 500).
- `backend/tests/test_cluster_status.py` — refresh-bypass, BE-only-denied, CN-generic-error, limited-mode placeholder name.
- `frontend/src/components/cluster/ClusterDrawer.test.tsx` — CN-only summary, unmount-aborts-fetch, limited-mode label, refresh button wiring.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_integration.py` — 194 pass
- [x] `ruff check backend/app/` clean
- [x] `tsc -b && vite build` clean (full build, not just `tsc --noEmit`)
- [x] `eslint src/ --max-warnings 0` clean
- [x] `vitest run` — 406 pass across 30 files
- [x] Docker image rebuilt + redeployed on port 8002
- [x] Live — Refresh button sends `?refresh=1` (verify in Network tab)
- [x] Live — Non-admin / limited-mode login: FE card shows "FE (connected)" + real host in IP slot
- [x] Live — Logout then log in as different user: drawer opens empty (no stale expanded nodes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)